### PR TITLE
Build.PL: Use Module::Build >= 0.3624's more portable way of specifying GPL3

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -4,7 +4,7 @@ use Module::Build;
 
 my $builder = Module::Build->new(
 	module_name         => 'Test::MockModule',
-	license             => 'gpl3',
+	license             => 'GPL_3',
 	dist_author         => [q{Current Maintainer: Geoff Franks <gfranks@cpan.org>}, q{Original Author: Simon Flack <simonflk _AT_ cpan.org>}],
 	dist_version_from   => 'lib/Test/MockModule.pm',
 	meta_merge => {


### PR DESCRIPTION
`gpl3` was not supported under META 1.0, and so gets normalised to
`open_source` in both META1.0 (.yml) and META2.0 (.json)
- https://metacpan.org/source/GFRANKS/Test-MockModule-0.08/META.json#L10
- https://metacpan.org/source/GFRANKS/Test-MockModule-0.08/META.yml#L12

However, since Module::Build 0.3624, Module::Build used
Software::License to provision license fields, and so any value of
`license => X` can be mapped to `Software::License::X`.

Here, this gives us [`Software::License::GPL_3`](https://metacpan.org/pod/Software::License::GPL_3), which stipulates that it
be represented as `gpl` in META1.0, and `gpl_3` in META2.0

https://metacpan.org/source/RJBS/Software-License-0.103010/lib/Software/License/GPL_3.pm#L10

( Apologies for not spotting this mistake earlier when you commented on it being fixed =) )
