### PR TITLE
Avoid indirect object syntax in constructors

### DIFF
--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -175,7 +175,7 @@ Test::MockModule - Override subroutines in a module for unit testing
 	use Test::MockModule;
 
 	{
-		my $module = new Test::MockModule('Module::Name');
+		my $module = Test::MockModule->new('Module::Name');
 		$module->mock('subroutine', sub { ... });
 		Module::Name::subroutine(@args); # mocked
 	}
@@ -215,7 +215,7 @@ If there is no C<$VERSION> defined in C<$package>, the module will be
 automatically loaded. You can override this behaviour by setting the C<no_auto>
 option:
 
-	my $mock = new Test::MockModule('Module::Name', no_auto => 1);
+	my $mock = Test::MockModule->new('Module::Name', no_auto => 1);
 
 =item get_package()
 

--- a/t/inheritance.t
+++ b/t/inheritance.t
@@ -13,7 +13,7 @@ is(Bar->motto(), "Foo!", "pre-mock: Bar inherit's Foo's motto");
 is(Baz->motto(), "Foo!", "pre-mock: Baz inherit's Bar's inheritance of Foo's motto");
 
 {
-	my $mock_bar = new Test::MockModule('Bar', no_auto => 1);
+	my $mock_bar = Test::MockModule->new('Bar', no_auto => 1);
 	$mock_bar->mock('motto', sub { 'Bar!' });
 	is(Foo->motto(), "Foo!", "Foo motto is unchanged post-Bar mock");
 	is(Bar->motto(), "Bar!", "Bar motto has been mocked");
@@ -21,7 +21,7 @@ is(Baz->motto(), "Foo!", "pre-mock: Baz inherit's Bar's inheritance of Foo's mot
 	is($mock_bar->original("motto")->(), "Foo!", "Bar's original function can still be reached correctly");
 	ok($mock_bar->is_mocked("motto"), "Baz's motto is really mocked");
 
-	my $mock_baz = new Test::MockModule('Baz', no_auto => 1);
+	my $mock_baz = Test::MockModule->new('Baz', no_auto => 1);
 	$mock_baz->mock('motto', sub { 'Baz!' });
 	is(Foo->motto(), "Foo!", "Foo motto is unchanged post-Baz mock");
 	is(Bar->motto(), "Bar!", "Bar motto is unchanged post-Baz mock");


### PR DESCRIPTION
The Perl object documentation (http://perldoc.perl.org/perlobj.html) states that indirect object syntax in constructors is discouraged and should be avoided.  This PR converts the indirect object syntax used for some constructor calls into a method call.  The tests pass and the POD has been updated accordingly.
