### PR TITLE
Remove Subversion Id tags

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,4 @@
 Revision history for Test::MockModule
-$Id: Changes,v 1.5 2005/03/24 22:23:38 simonflack Exp $
 
 v0.10 2015-05-30
     - Updated docs for mocking when using exported functions

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -1,4 +1,3 @@
-# $Id: MockModule.pm,v 1.7 2005/03/24 22:23:38 simonflack Exp $
 package Test::MockModule;
 use strict qw/subs vars/;
 use vars qw/$VERSION/;

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,5 +1,4 @@
 #!/usr/bin/perl
-#$Id: pod.t,v 1.1.1.1 2004/11/28 23:38:28 simonflack Exp $
 use Test::More;
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -1,5 +1,4 @@
 #!/usr/bin/perl
-#$Id: pod_coverage.t,v 1.1 2005/03/24 22:23:38 simonflack Exp $
 use Test::More;
 eval "use Test::Pod::Coverage 1.00";
 plan skip_all => "Test::Pod::Coverage 1.00 required for testing pod coverage" if $@;


### PR DESCRIPTION
Since this project is now hosted in Git, it's no longer necessary to keep
the Subversion tags around.
