### PR TITLE
Add warnings and strict pragmas to tests

### DIFF
--- a/t/inheritance.t
+++ b/t/inheritance.t
@@ -1,5 +1,8 @@
 #!/usr/bin/perl
 
+use warnings;
+use strict;
+
 use Test::MockModule;
 use Test::More;
 

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 #$Id: pod.t,v 1.1.1.1 2004/11/28 23:38:28 simonflack Exp $
+
+use warnings;
+use strict;
+
 use Test::More;
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;

--- a/t/pod_coverage.t
+++ b/t/pod_coverage.t
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 #$Id: pod_coverage.t,v 1.1 2005/03/24 22:23:38 simonflack Exp $
+
+use warnings;
+use strict;
+
 use Test::More;
 eval "use Test::Pod::Coverage 1.00";
 plan skip_all => "Test::Pod::Coverage 1.00 required for testing pod coverage" if $@;


### PR DESCRIPTION
In the case of `inheritance.t` warnings and strict did need to be turned on.
In the POD tests the strictures aren't strictly necessary, however including
them is best practice.
