### PR TITLE
Specify the minimum perl version

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -20,6 +20,7 @@ my $builder = Module::Build->new(
 		'Module::Build' => '0.38',
 	},
 	requires => {
+	        'perl'                => 5.006,
 		'Carp'                => 0,
 		'Scalar::Util'        => 0,
 		'SUPER'               => 0,


### PR DESCRIPTION
This is one of the experimental metrics mentioned on CPANTS
(http://cpants.cpanauthors.org/dist/Test-MockModule) and is generally a good
idea.  Neil Bower's `Perl::MinimumVersion` showed that the minimum required
Perl version for this module is 5.6, hence the value set here.
