### PR TITLE
Add coveralls code coverage info to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,9 @@ perl:
     - "5.14"
     - "5.12"
     - "5.10"
+
+before_install:
+    cpanm -n Devel::Cover::Report::Coveralls
+
+script:
+    perl Build.PL && ./Build build && cover -test -report coveralls


### PR DESCRIPTION
I'm not 100% sure if you want this added to the project, nevertheless, it's nice to have the code coverage checked automatically, and https://coveralls.io checks this for open source projects for free.
