### PR TITLE
Skip Travis-CI config file in MANIFEST

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -73,3 +73,5 @@
 ^Test-MockModule-*
 ^t/tmp
 
+# Avoid Travis-CI configuration file
+\.travis.yml


### PR DESCRIPTION
I should have added this as part of the `.travis.yml` PR, my apologies!
