### PR TITLE
Add method to conveniently no-op

### DIFF
--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -74,6 +74,11 @@ sub mock {
 	}
 }
 
+sub noop {
+    my $self = shift;
+    $self->mock($_,1) for @_;
+}
+
 sub original {
 	my $self = shift;
 	my ($name) = @_;
@@ -326,6 +331,14 @@ C<unmock()> in one go.
 Restores all the subroutines in the package that were mocked. This is
 automatically called when all C<Test::MockObject> objects for the given package
 go out of scope.
+
+=item noop($subroutine [, ...])
+
+Given a list of subroutine names, mocks each of them with a no-op subroutine. Handy
+for mocking methods you want to ignore!
+
+    # Neuter a list of methods in one go
+    $module->noop('purge', 'updated');
 
 =back
 

--- a/t/lib/ExampleModule.pm
+++ b/t/lib/ExampleModule.pm
@@ -13,4 +13,8 @@ sub param {
 	return;
 }
 
+sub cookie {
+    return 'choc-chip';
+}
+
 1;

--- a/t/mockmodule.t
+++ b/t/mockmodule.t
@@ -121,6 +121,16 @@ like($@, qr/Invalid package name/, ' ... croaks if package is undefined');
 	$mcgi->mock('param', sub { return 'This sub is mocked' });
 	is(ExampleModule::param(), 'This sub is mocked', '... mocked params');
 	ok($mcgi->is_mocked('param'), '... returns true for non-mocked sub');
+
+	# noop()
+	is(ExampleModule::cookie(), 'choc-chip', 'cookie does default behaviour');
+	$mcgi->noop('cookie');
+    ok($mcgi->is_mocked('cookie'), 'cookie is mocked using noop');
+    $mcgi->unmock('cookie');
+    $mcgi->unmock('Vars');
+    $mcgi->noop('cookie', 'Vars');
+    is(ExampleModule::cookie(), 1, 'now cookie does nothing');
+    is(ExampleModule::Vars(), 1, 'now Vars does nothing');
 }
 
 isnt(ExampleModule::param(), 'This sub is mocked',

--- a/t/mockmodule.t
+++ b/t/mockmodule.t
@@ -125,12 +125,12 @@ like($@, qr/Invalid package name/, ' ... croaks if package is undefined');
 	# noop()
 	is(ExampleModule::cookie(), 'choc-chip', 'cookie does default behaviour');
 	$mcgi->noop('cookie');
-    ok($mcgi->is_mocked('cookie'), 'cookie is mocked using noop');
-    $mcgi->unmock('cookie');
-    $mcgi->unmock('Vars');
-    $mcgi->noop('cookie', 'Vars');
-    is(ExampleModule::cookie(), 1, 'now cookie does nothing');
-    is(ExampleModule::Vars(), 1, 'now Vars does nothing');
+	ok($mcgi->is_mocked('cookie'), 'cookie is mocked using noop');
+	$mcgi->unmock('cookie');
+	$mcgi->unmock('Vars');
+	$mcgi->noop('cookie', 'Vars');
+	is(ExampleModule::cookie(), 1, 'now cookie does nothing');
+	is(ExampleModule::Vars(), 1, 'now Vars does nothing');
 }
 
 isnt(ExampleModule::param(), 'This sub is mocked',


### PR DESCRIPTION
Hello!

A lot of the time we want to skip certain methods as they don't have any relevance to the part of the code we are testing, e.g. when we don't want a subclass to perform a method that calls for non-crucial data. These methods often end up getting mocked in the following way:

`$mockmodule->mock(get_extra_info => sub {});`

With a no-op function, we can make it clear to the reader of the test that these functions are made to not do anything:

`$mockmodule->noop('get_extra_info');`

As you can see, it also saves some typing ;)