### PR TITLE
Add a redefine() method.

### DIFF
--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -46,6 +46,20 @@ sub get_package {
 	return $self->{_package};
 }
 
+sub redefine {
+	my ($self, @mocks) = (shift, @_);
+
+	while ( my ($name, $value) = splice @mocks, 0, 2 ) {
+		my $sub_name = $self->_full_name($name);
+		my $coderef = *{$sub_name}{'CODE'};
+		if ('CODE' ne ref $coderef) {
+			croak "$sub_name does not exist!";
+		}
+	}
+
+	return $self->mock(@_);
+}
+
 sub mock {
 	my $self = shift;
 
@@ -182,6 +196,10 @@ Test::MockModule - Override subroutines in a module for unit testing
 		my $module = Test::MockModule->new('Module::Name');
 		$module->mock('subroutine', sub { ... });
 		Module::Name::subroutine(@args); # mocked
+
+		#Same effect, but this will die() if other_subroutine()
+		#doesn't already exist, which is often desirable.
+		$module->redefine('other_subroutine', sub { ... });
 	}
 
 	Module::Name::subroutine(@args); # original subroutine
@@ -316,6 +334,13 @@ you can instead mock it in the module you are testing:
 	my $mymodule = Test::MockModule->new("MyModule", no_auto => 1);
 	$mymodule->mock("strftime", "Yesterday");
 	is MyModule::minus_twentyfour(), "Yesterday", "`minus-tewntyfour` got mocked"; # suceeds
+
+=item redefine($subroutine)
+
+The same behavior as C<mock()>, but this will preemptively check to be
+sure that all passed subroutines actually exist. This is useful to ensure that
+if a mocked module's interface changes the test doesn't just keep on testing a
+code path that no longer behaves consistently with the mocked behavior.
 
 =item original($subroutine)
 

--- a/t/redefine.t
+++ b/t/redefine.t
@@ -1,0 +1,27 @@
+use warnings;
+use strict;
+
+use Test::More;
+
+use Test::MockModule;
+
+my $mocker = Test::MockModule->new('Mockee');
+
+$mocker->redefine('good', 2);
+is( Mockee::good(), 2, 'redefine() redefines the function' );
+
+eval { $mocker->redefine('bad', 6) };
+like( $@, qr/Mockee::bad/, 'exception when redefine()ing a nonexistent function' );
+
+done_testing();
+
+#----------------------------------------------------------------------
+
+package Mockee;
+
+our $VERSION;
+BEGIN { $VERSION = 1 };
+
+sub good { 1 }
+
+1;


### PR DESCRIPTION
Issue #17: This new method is useful to ensure that we don’t mock
an interface that doesn’t exist.