### PR TITLE
Add use warnings

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -27,6 +27,7 @@ my $builder = Module::Build->new(
 	},
 	build_requires => {
 		'Test::More'          => 0.88,
+		'Test::Warnings'      => 0
 	},
 
 	add_to_cleanup => [

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -1,4 +1,5 @@
 package Test::MockModule;
+use warnings;
 use strict qw/subs vars/;
 use vars qw/$VERSION/;
 use Scalar::Util qw/reftype weaken/;

--- a/t/inheritance.t
+++ b/t/inheritance.t
@@ -3,6 +3,7 @@ use strict;
 
 use Test::MockModule;
 use Test::More;
+use Test::Warnings;
 
 @Bar::ISA = 'Foo';
 @Baz::ISA = 'Bar';

--- a/t/mockmodule.t
+++ b/t/mockmodule.t
@@ -2,6 +2,7 @@ use warnings;
 use strict;
 
 use Test::More;
+use Test::Warnings;
 
 use lib "t/lib";
 

--- a/t/redefine.t
+++ b/t/redefine.t
@@ -2,6 +2,7 @@ use warnings;
 use strict;
 
 use Test::More;
+use Test::Warnings;
 
 use Test::MockModule;
 


### PR DESCRIPTION
This fixes the cpants warning
https://cpants.cpanauthors.org/dist/Test-MockModule

This has been done as part of the Pull Request Challenge.

Tests are passing and test coverage is good so I don't think adding use warnings has broken anything