### PR TITLE
Allow redefine when parent provides the sub

### DIFF
--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -53,6 +53,14 @@ sub redefine {
 	while ( my ($name, $value) = splice @mocks, 0, 2 ) {
 		my $sub_name = $self->_full_name($name);
 		my $coderef = *{$sub_name}{'CODE'};
+		next if 'CODE' eq ref $coderef;
+
+		if ( $sub_name =~ qr{^(.+)::([^:]+)$} ) {
+			my ( $pkg, $sub ) = ( $1, $2 );
+			my $object = bless {}, $pkg;
+			next if $object->can( $sub );
+		}
+
 		if ('CODE' ne ref $coderef) {
 			croak "$sub_name does not exist!";
 		}
@@ -342,6 +350,9 @@ The same behavior as C<mock()>, but this will preemptively check to be
 sure that all passed subroutines actually exist. This is useful to ensure that
 if a mocked module's interface changes the test doesn't just keep on testing a
 code path that no longer behaves consistently with the mocked behavior.
+
+Note that redefine is also now checking if one of the parent provides the sub
+and will not die if it's available in the chain.
 
 =item original($subroutine)
 

--- a/t/inheritance.t
+++ b/t/inheritance.t
@@ -40,4 +40,51 @@ is(Baz->motto(), "Foo!", "pre-mock: Baz inherit's Bar's inheritance of Foo's mot
 is(Foo->motto(), "Foo!", "post-unmock: Foo original motto is correct");
 is(Bar->motto(), "Foo!", "post-unmock: Bar inherit's Foo's motto");
 is(Baz->motto(), "Foo!", "post-unmock: Baz inherit's Bar's inheritance of Foo's motto");
+
+{
+	BEGIN {
+		$INC{'Mother.pm'} = '__MOCKED__';
+		$INC{'InvalidChild.pm'} = '__MOCKED__';
+		$INC{'ValidChild.pm'} = '__MOCKED__';
+	}
+	package Mother;
+
+	sub do_something { 1 }
+
+	package InvalidChild;
+
+	sub abcd { 1 }
+
+	package ValidChild;
+
+	use parent q{Mother};
+
+	sub abcd { 1 }
+}
+
+package main;
+
+{
+	my $mock_child = Test::MockModule->new( 'InvalidChild' );
+
+	local $@;
+	ok ! eval { $mock_child->redefine( 'do_something', sub { 42 } ); 1 }, "cannot redefine do_something";
+	like $@, qr{InvalidChild::do_something does not exist!}, "throw a die";
+}
+
+{
+	my $mock_child = Test::MockModule->new( 'ValidChild' );
+
+	local $@;
+	ok eval { $mock_child->redefine( 'do_something', sub { 42 } ); 1 }, "cann redefine do_something when parent define this function";
+	is $@, '', 'no warnings';
+
+	my $object = bless {}, 'ValidChild';
+	is $object->do_something(), 42, "mocked value from do_something";
+
+	$mock_child->unmock( 'do_something' );
+	is $object->do_something(), 1, "do_something is now unmocked";
+}
+
+
 done_testing;


### PR DESCRIPTION
Try the ISA chain to check if the sub exists in one of the parent.

Note that this is a behavior change proposal, I think it's a good option to let redefine check for parents by default. But discussion is open if we prefer to add an option or provide another name to the function to preserve backward compatibility with the original behavior.

Thanks for considering such an option
nicolas