### PR TITLE
Block prototype warnings when redefining a subroutine

### DIFF
--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -157,8 +157,10 @@ sub _valid_subname {
 
 sub _replace_sub {
 	my ($sub_name, $coderef) = @_;
-	# from Test::MockObject
-	local $SIG{__WARN__} = sub { warn $_[0] unless $_[0] =~ /redefined/ };
+
+    no warnings 'redefine';
+    no warnings 'prototype';
+
 	if (defined $coderef) {
 		*{$sub_name} = $coderef;
 	} else {

--- a/t/prototype.t
+++ b/t/prototype.t
@@ -1,0 +1,30 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::Warnings;
+
+package Mockee;
+
+sub good ($$);
+
+sub good ($$) {
+    my ( $bar, $baz ) = @_;
+    return ( $bar + 1, $baz + 2 );
+}
+
+1;
+
+package main;
+
+use Test::MockModule;
+
+$INC{'Mockee.pm'} = 1;
+my $mocker = Test::MockModule->new('Mockee');
+
+$mocker->redefine( 'good', 2 );
+
+done_testing();
+
+#----------------------------------------------------------------------
+


### PR DESCRIPTION
Fixes https://github.com/geofffranks/test-mockmodule/issues/28