### PR TITLE
Provide define method so the mock method is unneeded in tests.

### DIFF
--- a/t/define.t
+++ b/t/define.t
@@ -1,0 +1,35 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::Warnings;
+
+use Test::MockModule;
+
+my $mocker = Test::MockModule->new('Mockee');
+
+$mocker->define( 'doesnt_exist', 2 );
+is( Mockee::doesnt_exist(), 2, 'define() allows us to mock nonexistant subroutines.' );
+
+eval { $mocker->define( 'existing_subroutine', 6 ) };
+like( $@, qr/Mockee::existing_subroutine exists\!/, 'exception when define()ing an existing subroutine' );
+
+undef $mocker;
+is( Mockee->can('doesnt_exist'), undef, "the defined sub went away after mocker is undeffed" );
+$mocker = Test::MockModule->new('Mockee');
+
+$mocker->define( 'doesnt_exist', 3 );
+is( Mockee::doesnt_exist(), 3, 'The subroutine can be defined again after the mock object goes out of scope and is re-instantiated.' );
+
+done_testing();
+
+#----------------------------------------------------------------------
+
+package Mockee;
+
+our $VERSION;
+BEGIN { $VERSION = 1 }
+
+sub existing_subroutine { 1 }
+
+1;


### PR DESCRIPTION
We are trying to ban the use of mock in our code base, however we ran into a few cases where the use case was not to redefine an existing sub, but instead to define a missing sub.

unlike mock, define() would fail if the subroutine being defined exists.