### PR TITLE
Strict

### DIFF
--- a/t/define.t
+++ b/t/define.t
@@ -1,0 +1,35 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::Warnings;
+
+use Test::MockModule;
+
+my $mocker = Test::MockModule->new('Mockee');
+
+$mocker->define( 'doesnt_exist', 2 );
+is( Mockee::doesnt_exist(), 2, 'define() allows us to mock nonexistant subroutines.' );
+
+eval { $mocker->define( 'existing_subroutine', 6 ) };
+like( $@, qr/Mockee::existing_subroutine exists\!/, 'exception when define()ing an existing subroutine' );
+
+undef $mocker;
+is( Mockee->can('doesnt_exist'), undef, "the defined sub went away after mocker is undeffed" );
+$mocker = Test::MockModule->new('Mockee');
+
+$mocker->define( 'doesnt_exist', 3 );
+is( Mockee::doesnt_exist(), 3, 'The subroutine can be defined again after the mock object goes out of scope and is re-instantiated.' );
+
+done_testing();
+
+#----------------------------------------------------------------------
+
+package Mockee;
+
+our $VERSION;
+BEGIN { $VERSION = 1 }
+
+sub existing_subroutine { 1 }
+
+1;

--- a/t/mock_strict.t
+++ b/t/mock_strict.t
@@ -1,0 +1,40 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::Warnings;
+
+use Test::MockModule qw/strict/;
+
+my $mocker = Test::MockModule->new('Mockee');
+
+is( $Test::MockModule::STRICT_MODE, 1, "use Test::MockModule qw/strict/; sets \$STRICT_MODE to 1" );
+
+eval { $mocker->mock( 'foo', 2 ) };
+like( "$@", qr/^mock is not allowed in strict mode. Please use define or redefine at/, "mock croaks in strict mode." );
+
+eval { $mocker->noop('foo') };
+like( "$@", qr/^noop is not allowed in strict mode. Please use define or redefine at/, "noop croaks in strict mode." );
+
+$mocker->define( 'foo', "abc" );
+is( Mockee->foo, "abc", "define is allowed in strict mode." );
+
+$mocker->redefine( 'existing_subroutine', "def" );
+is( Mockee->existing_subroutine, "def", "redefine is allowed in strict mode." );
+
+$Test::MockModule::STRICT_MODE = 0;
+$mocker->mock( 'foo', 123 );
+is( Mockee->foo, 123, "mock is allowed when strict mode is turned off." );
+
+done_testing();
+
+#----------------------------------------------------------------------
+
+package Mockee;
+
+our $VERSION;
+BEGIN { $VERSION = 1 }
+
+sub existing_subroutine { 1 }
+
+1;


### PR DESCRIPTION
I'd like to provide a way to ban noop and mock. We've run into several bugs in our own code because we mock something and everything's great then the underlying code gets re-factored and nobody notices.

We fixed many of these problems by switching our code over to redefine. But there are cases where people need to define subroutines that didn't actually exist before then. So I've introduced a method called define. It blows up if there was a previous subroutine there.

Finally, I need a mode that breaks if someone calls mock or noop. This ensures nobody accidentally codes using the less safe methods. By default the code will behave like it always did. But strict mode will help it to encourage people to be more safe if they use it.