### PR TITLE
Prevent redefine() from triggering DESTROY.

### DIFF
--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -66,8 +66,7 @@ sub redefine {
 
 		if ( $sub_name =~ qr{^(.+)::([^:]+)$} ) {
 			my ( $pkg, $sub ) = ( $1, $2 );
-			my $object = bless {}, $pkg;
-			next if $object->can( $sub );
+			next if $pkg->can( $sub );
 		}
 
 		if ('CODE' ne ref $coderef) {

--- a/t/redefine.t
+++ b/t/redefine.t
@@ -14,6 +14,10 @@ is( Mockee::good(), 2, 'redefine() redefines the function' );
 eval { $mocker->redefine('bad', 6) };
 like( $@, qr/Mockee::bad/, 'exception when redefine()ing a nonexistent function' );
 
+my $mocker2 = Test::MockModule->new('MockeeWithDestroy');
+
+eval { $mocker2->redefine('what', 2) };
+
 done_testing();
 
 #----------------------------------------------------------------------
@@ -24,5 +28,14 @@ our $VERSION;
 BEGIN { $VERSION = 1 };
 
 sub good { 1 }
+
+#----------------------------------------------------------------------
+
+package MockeeWithDestroy;
+
+our $VERSION;
+BEGIN { $VERSION = 1 };
+
+sub DESTROY { print 'bad' if $_[0][1] };
 
 1;


### PR DESCRIPTION
Issue #35 