### PR TITLE
Allow chaining of new with mock, redefine, define

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Test::MockModule
 
+{{NEXT}}
+- allow chaining of new with mock, redefine, define
+
 v0.170.0
 - 182d066 Fix versioning for semver conversion + PAUSE - Geoff Franks
 - 4afeedf release v0.17.0 - CI Bot

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -127,6 +127,8 @@ sub _mock {
 		TRACE("Installing mocked $sub_name");
 		_replace_sub($sub_name, $code);
 	}
+
+	return $self;
 }
 
 sub noop {
@@ -135,6 +137,8 @@ sub noop {
     croak "noop is not allowed in strict mode. Please use define or redefine" if $STRICT_MODE;
 
     $self->_mock($_,1) for @_;
+
+    return;
 }
 
 sub original {
@@ -169,6 +173,8 @@ sub unmock_all {
 	foreach (keys %{$self->{_mocked}}) {
 		$self->unmock($_);
 	}
+
+	return;
 }
 
 sub is_mocked {
@@ -251,6 +257,15 @@ Test::MockModule - Override subroutines in a module for unit testing
 		$module->define('another_subroutine', sub { ... });
 	}
 
+	{
+		# you can also chain new/mock/redefine/define
+
+		Test::MockModule->new('Module::Name')
+		->mock( one_subroutine => sub { ... })
+		->redefine( other_subroutine => sub { ... } )
+		->define( a_new_sub => 1234 );
+	}
+
 	Module::Name::subroutine(@args); # original subroutine
 
 	# Working with objects
@@ -314,6 +329,10 @@ mocked
 Temporarily replaces one or more subroutines in the mocked module. A subroutine
 can be mocked with a code reference or a scalar. A scalar will be recast as a
 subroutine that returns the scalar.
+
+Returns the current C<Test::MockModule> object, so you can chain L<new> with L<mock>.
+
+	my $mock = Test::MockModule->new->(...)->mock(...);
 
 The following statements are equivalent:
 
@@ -406,6 +425,10 @@ code path that no longer behaves consistently with the mocked behavior.
 Note that redefine is also now checking if one of the parent provides the sub
 and will not die if it's available in the chain.
 
+Returns the current C<Test::MockModule> object, so you can chain L<new> with L<redefine>.
+
+	my $mock = Test::MockModule->new->(...)->redefine(...);
+
 =item define($subroutine)
 
 The reverse of redefine, this will fail if the passed subroutine exists.
@@ -417,6 +440,10 @@ By using define, you're asserting that the subroutine you want to be mocked
 should not exist in advance.
 
 Note: define does not check for inheritance like redefine.
+
+Returns the current C<Test::MockModule> object, so you can chain L<new> with L<define>.
+
+	my $mock = Test::MockModule->new->(...)->define(...);
 
 =item original($subroutine)
 

--- a/t/chaining.t
+++ b/t/chaining.t
@@ -1,0 +1,30 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::Warnings;
+
+use Test::MockModule;
+
+my $mocker = Test::MockModule->new('Mockee')->mock( good => 51 )
+  ->redefine( to_redefine => sub { 42 } )->define( something => 1234 );
+
+isa_ok $mocker, 'Test::MockModule';
+
+is( Mockee::good(),        51,   'mock() works when chaining with new' );
+is( Mockee::to_redefine(), 42,   'redefine() works when chaining with new' );
+is( Mockee::something(),   1234, 'something() works when chaining with new' );
+
+done_testing();
+
+#----------------------------------------------------------------------
+
+package Mockee;
+
+our $VERSION;
+BEGIN { $VERSION = 1 }
+
+sub good        { 1 }
+sub to_redefine { 1 }
+
+1;


### PR DESCRIPTION
Resolves #34

'mock', 'redefine' and 'define' functions now
return the current 'Test::MockModule' object so
we can chain the functions.

The previous return value was undocumented and
unclear so this should not break previous usages.