### PR TITLE
Add warning when 'unmock' called without arguments

### DIFF
--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -150,6 +150,7 @@ sub original {
 sub unmock {
 	my $self = shift;
 
+	carp 'Nothing to unmock' unless @_;
 	for my $name (@_) {
 		croak "Invalid subroutine name: $name" unless _valid_subname($name);
 

--- a/t/mockmodule.t
+++ b/t/mockmodule.t
@@ -103,6 +103,9 @@ like($@, qr/Invalid package name/, ' ... croaks if package is undefined');
 	$mcgi->unmock('Vars');
 	like($warn, qr/ was not mocked/, "... warns if a subroutine isn't mocked");
 
+	$mcgi->unmock();
+	like($warn, qr/Nothing to unmock/, '... warns if no arguments passed to unmock');
+
 	$mcgi->unmock('param');
 	is(\&{"ExampleModule::param"}, $orig_param, '... restores the original subroutine');
 


### PR DESCRIPTION
I didn't RTFM and for some reason thought `unmock` would do something if no args were passed. Add a useful warning for the sake of my foolishness, not sure how valuable it might be to anyone else.