### PR TITLE
Remove Software::License from runtime dependencies

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -23,7 +23,6 @@ my $builder = Module::Build->new(
 		'Carp'                => 0,
 		'Scalar::Util'        => 0,
 		'SUPER'               => '1.20',
-		'Software::License' => '0.104006',
 	},
 	test_requires => {
 		'Test::More'          => 0.88,


### PR DESCRIPTION
I think this should do - Software::License is probably only needed in publish-cpan action, and this action already installs it manually. 
Resolves #67