### PR TITLE
Fix GH #83: closure-captures-$mock leak — warning + escape paths

### DIFF
--- a/.github/workflows/publish-cpan.yml
+++ b/.github/workflows/publish-cpan.yml
@@ -71,6 +71,7 @@ jobs:
             Test::Warnings
             Test::More
             Carp
+            PadWalker
             Scalar::Util
             SUPER
             Software::License

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -29,6 +29,7 @@ jobs:
           install: |
             Carp
             Module::Build
+            PadWalker
             Scalar::Util
             SUPER
             Test::More
@@ -72,6 +73,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: perl -V
+      - name: install dependencies
+        uses: perl-actions/install-with-cpm@v2
+        with:
+          install: |
+            PadWalker
       - run: perl Build.PL
       - run: ./Build
       - run: ./Build test

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -22,18 +22,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - uses: shogo82148/actions-setup-perl@v1
       - run: perl -V
+      # Reads ALL deps (configure / runtime / test) from META.json /
+      # Build.PL. cpanm honors configure_requires automatically, so
+      # Module::Build gets pulled in before perl Build.PL runs.
+      # Single source of truth -- adding a new dep to Build.PL picks
+      # up here without a workflow edit.
       - name: install dependencies
-        uses: perl-actions/install-with-cpm@v2
-        with:
-          install: |
-            Carp
-            Module::Build
-            PadWalker
-            Scalar::Util
-            SUPER
-            Test::More
-            Test::Warnings
+        run: cpanm --installdeps --notest .
       - run: perl Build.PL
       - run: ./Build
       - run: ./Build test
@@ -73,11 +70,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: perl -V
+      # perldocker/perl-tester images ship with cpanm + Module::Build
+      # preinstalled, so no bootstrap step needed. Same `cpanm
+      # --installdeps` pattern as the ubuntu job; reads Build.PL
+      # directly. Avoids the sudo-in-container failure mode of
+      # install-with-cpm and keeps the dep list in one place.
       - name: install dependencies
-        uses: perl-actions/install-with-cpm@v2
-        with:
-          install: |
-            PadWalker
+        run: cpanm --installdeps --notest .
       - run: perl Build.PL
       - run: ./Build
       - run: ./Build test

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -28,9 +28,13 @@ jobs:
       # Build.PL. cpanm honors configure_requires automatically, so
       # Module::Build gets pulled in before perl Build.PL runs.
       # Single source of truth -- adding a new dep to Build.PL picks
-      # up here without a workflow edit.
+      # up here without a workflow edit. Test::Perl::Critic is an
+      # author-only dep used by t/author-perlcritic.t; installed
+      # explicitly so the lint test runs in CI.
       - name: install dependencies
-        run: cpanm --installdeps --notest .
+        run: |
+          cpanm --installdeps --notest .
+          cpanm --notest Test::Perl::Critic Perl::Critic
       - run: perl Build.PL
       - run: ./Build
       - run: ./Build test

--- a/Build.PL
+++ b/Build.PL
@@ -2,7 +2,23 @@ use strict;
 use warnings;
 use Module::Build;
 
-my $builder = Module::Build->new(
+# Subclass to add a `./Build critic` action that runs Perl::Critic
+# against lib/ and t/ at the project's --gentle severity. Same check
+# as the author-mode test in t/author-perlcritic.t -- this just lets
+# you invoke it standalone without running the full test suite.
+my $class = Module::Build->subclass(
+	class => 'Test::MockModule::Builder',
+	code => <<'CRITIC_ACTION',
+sub ACTION_critic {
+	my $self = shift;
+	require Test::Perl::Critic;
+	Test::Perl::Critic->import(-severity => 'gentle');
+	Test::Perl::Critic::all_critic_ok('lib', 't');
+}
+CRITIC_ACTION
+);
+
+my $builder = $class->new(
 	module_name         => 'Test::MockModule',
 	create_license      => 1,
 	license             => 'perl',

--- a/Build.PL
+++ b/Build.PL
@@ -19,8 +19,9 @@ my $builder = Module::Build->new(
 		'Module::Build' => '0.4234',
 	},
 	requires => {
-	    'perl'                => 5.006,
+	    'perl'                => 5.008001,
 		'Carp'                => 0,
+		'PadWalker'           => '2.0',
 		'Scalar::Util'        => 0,
 		'SUPER'               => '1.20',
 	},

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,4 +3,4 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
-RUN apt-get install -y git libmodule-build-perl libsuper-perl libtest-warnings-perl libsuper-perl libtest-warnings-perl libtest-pod-coverage-perl libdevel-cover-perl libcpan-uploader-perl
+RUN apt-get install -y git libmodule-build-perl libpadwalker-perl libsuper-perl libtest-warnings-perl libsuper-perl libtest-warnings-perl libtest-pod-coverage-perl libdevel-cover-perl libcpan-uploader-perl

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -2,7 +2,7 @@ package Test::MockModule;
 use warnings;
 use strict qw/subs vars/;
 use vars qw/$VERSION/;
-use Scalar::Util qw/reftype refaddr/;
+use Scalar::Util qw/reftype refaddr weaken/;
 use PadWalker ();
 use Carp;
 use SUPER;
@@ -100,6 +100,15 @@ sub _detect_self_capture {
 #                way as orig, so the bottom-of-stack restore can use the
 #                correct pre-any-mock meta state.
 my %mock_subs;
+
+# Per-package weak registry for opt-in singleton mode (GH #83 escape hatch).
+# Pre-0.180 behavior: new() with singleton => 1 returns the existing object
+# for a package if one is alive. Weak ref so unmocked-and-GC'd objects
+# release the slot naturally; alive-via-leak objects (the GH #83 case)
+# stay reachable, which is exactly what we want -- subsequent new() calls
+# return the same $mock so user mock() calls overwrite the leaked closure.
+my %singleton;
+
 sub new {
 	my ($class, $package, %args) = @_;
 
@@ -107,6 +116,11 @@ sub new {
 	unless (_valid_package($package)) {
 		$package = 'undef' unless defined $package;
 		croak "Invalid package name $package";
+	}
+
+	if ($args{singleton} && $singleton{$package}) {
+		TRACE("Reusing singleton MockModule object for $package");
+		return $singleton{$package};
 	}
 
 	unless ($package eq "CORE::GLOBAL" || $package eq 'main' || $args{no_auto} || ${"$package\::VERSION"}) {
@@ -120,6 +134,12 @@ sub new {
 		_package => $package,
 		_mocked  => {},
 	}, $class;
+
+	if ($args{singleton}) {
+		$singleton{$package} = $self;
+		weaken($singleton{$package});
+	}
+
 	return $self;
 }
 

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -58,6 +58,14 @@ sub _strict_mode {
 sub _detect_self_capture {
 	my ($self, $code, $name) = @_;
 	return unless ref($code) eq 'CODE';
+	# Suppress the warning under singleton mode. Singleton mode does NOT
+	# break the closure's strong reference to $self -- the leak still
+	# exists -- but it makes the leak harmless: subsequent new(...,
+	# singleton => 1) calls return the same $self, and subsequent
+	# mock()s overwrite the leaked closure in the symbol table, so
+	# tests written against pre-0.180 semantics behave correctly. The
+	# user has explicitly opted into this trade-off; warning here would
+	# be noise.
 	return if $self->{_singleton};
 	my $self_addr = refaddr($self);
 	my $closed = eval { PadWalker::closed_over($code) };
@@ -474,8 +482,13 @@ sub original_for {
 	my $sub_name = "${package}::${name}";
 	my $stack = $mock_subs{$sub_name};
 	if ($stack && @$stack) {
-		my $orig = $stack->[0]{orig};
-		return $orig if defined $orig;
+		# Bottom-of-stack orig is the truly-original coderef. May be
+		# undef when the sub was created via define() -- the caller
+		# wanted "no pre-mock implementation" and that's exactly what
+		# we return. Falling through to \&$sub_name would hand back the
+		# active mock (an infinite-recursion footgun for closures that
+		# wrap their own original).
+		return $stack->[0]{orig};
 	}
 	no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
 	return \&$sub_name if defined &{$sub_name};
@@ -1086,8 +1099,11 @@ lexical scope (GH #83):
             ->original_for('MyModule', 'greet')->(@_) . '_suffix';
     });
 
-Returns C<undef> if the named sub does not exist. Stacked mocks return
-the truly-original (pre-any-mock) coderef, not the layer below.
+Returns C<undef> when there is no pre-mock implementation -- either
+because the sub does not exist at all, or because it was created via
+C<define()> (i.e. the bottom-of-stack has no original to restore).
+Stacked mocks return the truly-original (pre-any-mock) coderef, not
+the layer below.
 
 =item unmock($subroutine [, ...])
 

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -460,6 +460,28 @@ sub original {
 	return defined $self->{_orig}{$name} ? $self->{_orig}{$name} : $self->{_package}->super($name);
 }
 
+# GH #83-safe alternative to $mock->original(). Class method; takes
+# strings, returns the truly-original coderef from the per-package
+# registry (or the live sub if not mocked). Lets user closures avoid
+# capturing $mock, which is the root cause of the GH #83 DESTROY-leak.
+sub original_for {
+	my ($class, $package, $name) = @_;
+	croak "Invalid package name " . (defined $package ? $package : 'undef')
+		unless _valid_package($package);
+	croak 'Please provide a valid function name'
+		unless _valid_subname($name);
+
+	my $sub_name = "${package}::${name}";
+	my $stack = $mock_subs{$sub_name};
+	if ($stack && @$stack) {
+		my $orig = $stack->[0]{orig};
+		return $orig if defined $orig;
+	}
+	no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
+	return \&$sub_name if defined &{$sub_name};
+	return undef;
+}
+
 sub unmock {
 	my ( $self, @names ) = @_;
 

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -714,6 +714,16 @@ Test::MockModule - Override subroutines in a module for unit testing
 		$foo->foo(); # prints "Foo!\n"
 	}
 
+    # Calling the original from inside a mock (GH #83-safe pattern):
+    use Test::MockModule;
+
+    my $mock = Test::MockModule->new('Foo');
+    $mock->mock('foo', sub {
+        # Capture only strings -- not $mock -- so DESTROY can fire
+        # at end of scope.
+        return Test::MockModule->original_for('Foo', 'foo')->(@_) + 1;
+    });
+
     # If you want to prevent noop and mock from working, you can
     # load Test::MockModule in strict mode.
 
@@ -835,6 +845,21 @@ automatically loaded. You can override this behaviour by setting the C<no_auto>
 option:
 
 	my $mock = Test::MockModule->new('Module::Name', no_auto => 1);
+
+The C<singleton> option restores pre-v0.180 per-package singleton
+behavior, intended as an escape hatch for code hit by GH #83 (closures
+capturing C<$mock> prevent C<DESTROY>-driven cleanup):
+
+    my $mock = Test::MockModule->new('Module::Name', singleton => 1);
+    # A subsequent new('Module::Name', singleton => 1) returns the
+    # same object, so re-mocking replaces the leaked closure rather
+    # than stacking on top of it.
+
+Default behavior remains "fresh object per call" (see GH #48). The
+singleton registry is process-global per-package; tests sharing a
+process should be aware that a leaked singleton from one test file may
+be visible to a later one. Pair with C<< Test::MockModule->reset_for($pkg) >>
+in test teardown if you need to guarantee a clean slate.
 
 =item get_package()
 
@@ -982,6 +1007,30 @@ Returns the original (unmocked) subroutine. If the subroutine is not currently
 mocked, returns the existing subroutine directly instead of warning. This makes
 it safe to call C<original()> before or after mocking.
 
+B<GH #83 caveat>: calling C<< $mock->original >> from inside a mock
+closure causes the closure to capture C<$mock>. The captured strong
+reference prevents C<DESTROY> from firing when C<$mock> goes out of
+scope, so the mock leaks into subsequent tests. Two ways to avoid:
+
+=over 4
+
+=item *
+
+Capture C<< $mock->original >> in a lexical B<before> calling
+C<< $mock->mock >> (existing recommendation).
+
+=item *
+
+Use the class-method form C<< Test::MockModule->original_for($pkg, $sub) >>
+inside the closure, which captures only strings.
+
+=back
+
+C<Test::MockModule> emits a runtime warning when this pattern is
+detected at C<mock()> install time. The warning is suppressed when the
+mock object was created with C<< singleton => 1 >>, since that mode is
+itself a documented workaround for the leak.
+
 Here is a sample how to wrap a function with custom arguments using the original subroutine.
 This is useful when you cannot (do not) want to alter the original code to abstract
 one hardcoded argument pass to a function.
@@ -1020,6 +1069,23 @@ one hardcoded argument pass to a function.
 		}
 	});
 
+=item original_for($package, $subroutine)
+
+Class-method counterpart to C<original()>. Returns the truly-original
+coderef for C<$package::$subroutine> without requiring a C<$mock> object.
+Use this from inside a mock closure to avoid capturing C<$mock>, which
+otherwise prevents C<DESTROY>-driven unmock and leaks the mock past its
+lexical scope (GH #83):
+
+    my $mock = Test::MockModule->new('MyModule');
+    $mock->mock('greet', sub {
+        # Closure captures only strings -- $mock can be GC'd at end of scope
+        return Test::MockModule
+            ->original_for('MyModule', 'greet')->(@_) . '_suffix';
+    });
+
+Returns C<undef> if the named sub does not exist. Stacked mocks return
+the truly-original (pre-any-mock) coderef, not the layer below.
 
 =item unmock($subroutine [, ...])
 
@@ -1031,6 +1097,29 @@ C<unmock()> in one go.
 Restores all the subroutines in the package that were mocked. This is
 automatically called when all C<Test::MockModule> objects for the given package
 go out of scope.
+
+=item reset_for($package)
+
+Class-method teardown helper. Walks the per-sub registry and restores
+every mocked sub in C<$package>, regardless of which C<$mock> object
+owns it. Intended for test teardown blocks where the closure-captures-
+C<$mock> pattern (GH #83) has prevented mocks from being destroyed at
+scope exit:
+
+    END {
+        Test::MockModule->reset_for('My::Target::Module');
+    }
+
+No-op when called for a package with no active mocks. Croaks on invalid
+package names.
+
+B<Caveat>: any C<$mock> object that owned an entry in the cleared
+registry has stale internal state (C<_mocked> / C<_orig> hashes still
+think the sub is mocked). If your test code holds a reference to such a
+C<$mock> after C<reset_for> -- e.g. via C<< singleton => 1 >> lookup --
+do not call C<unmock> / C<unmock_all> on it, as those will try to
+restore an already-restored symbol. Treat C<reset_for> as a one-shot
+end-of-scope cleanup.
 
 =item noop($subroutine [, ...])
 

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -58,6 +58,7 @@ sub _strict_mode {
 sub _detect_self_capture {
 	my ($self, $code, $name) = @_;
 	return unless ref($code) eq 'CODE';
+	return if $self->{_singleton};
 	my $self_addr = refaddr($self);
 	my $closed = eval { PadWalker::closed_over($code) };
 	return unless ref $closed eq 'HASH';
@@ -136,6 +137,7 @@ sub new {
 	}, $class;
 
 	if ($args{singleton}) {
+		$self->{_singleton} = 1;
 		$singleton{$package} = $self;
 		weaken($singleton{$package});
 	}

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -526,6 +526,55 @@ sub unmock_all {
 	return;
 }
 
+# GH #83 escape hatch: class-level cleanup helper. Walks %mock_subs and
+# restores every mocked sub belonging to $package, regardless of which
+# mock object owns the entry. Useful in test teardown blocks where the
+# closure-captures-$mock pattern has leaked mocks past their lexical
+# scope and DESTROY is never going to fire.
+sub reset_for {
+	my ($class, $package) = @_;
+	croak "Invalid package name " . (defined $package ? $package : 'undef')
+		unless _valid_package($package);
+
+	my $prefix = "${package}::";
+	my @sub_names = grep { 0 == index($_, $prefix) } keys %mock_subs;
+
+	for my $sub_name (@sub_names) {
+		my $stack = $mock_subs{$sub_name};
+		next unless $stack && @$stack;
+
+		# Bottom of stack carries the truly-original orig (cascade in
+		# unmock() preserves this invariant on mid-stack splices).
+		my $bottom = $stack->[0];
+		my ($name) = $sub_name =~ /::([^:]+)$/;
+
+		my $meta = _meta_for($package);
+		my $can_meta = $meta && !$meta->is_immutable;
+		if ($bottom->{is_meta} && $can_meta) {
+			my $orig_method = $bottom->{meta_orig};
+			if (defined $orig_method) {
+				my $arg = $meta->isa('Mouse::Meta::Class')
+					? (ref($orig_method) eq 'CODE' ? $orig_method : $orig_method->body)
+					: $orig_method;
+				$meta->add_method($name, $arg);
+			} else {
+				if ($meta->can('remove_method')) {
+					$meta->remove_method($name);
+				} else {
+					delete $meta->{methods}{$name};
+				}
+				_replace_sub($sub_name, $bottom->{orig});
+			}
+		} else {
+			_replace_sub($sub_name, $bottom->{orig});
+		}
+
+		delete $mock_subs{$sub_name};
+	}
+
+	return;
+}
+
 sub is_mocked {
 	my ($self, $name) = @_;
 

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -586,6 +586,8 @@ sub reset_for {
 		delete $mock_subs{$sub_name};
 	}
 
+	delete $singleton{$package};
+
 	return;
 }
 

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -3,6 +3,7 @@ use warnings;
 use strict qw/subs vars/;
 use vars qw/$VERSION/;
 use Scalar::Util qw/reftype refaddr/;
+use PadWalker ();
 use Carp;
 use SUPER;
 # This is now auto-updated at release time by the github action
@@ -44,6 +45,38 @@ sub _strict_mode {
         }
     }
     return 0;
+}
+
+# GH #83: Detect when a user's mock closure captures the mock object
+# itself ($self). This pattern -- e.g. `$mock->mock('foo', sub { $mock->original('foo')->() })`
+# -- creates a strong reference chain symbol_table -> $code -> captured $self
+# that prevents DESTROY from firing, so the mock leaks past its lexical scope.
+# Diagnose only; never modify the user's coderef. PadWalker pad-slot weakening
+# was investigated and ruled out (pad slots are aliased to the parent's
+# lexical, so weakening from inside _mock immediately kills $mock before the
+# user's test code can run).
+sub _detect_self_capture {
+	my ($self, $code, $name) = @_;
+	return unless ref($code) eq 'CODE';
+	my $self_addr = refaddr($self);
+	my $closed = eval { PadWalker::closed_over($code) };
+	return unless ref $closed eq 'HASH';
+	for my $varname (keys %$closed) {
+		my $slot = $closed->{$varname};
+		next unless ref($slot) eq 'REF';
+		my $val = $$slot;
+		next unless ref($val) && refaddr($val) == $self_addr;
+		carp sprintf(
+			"Test::MockModule: closure for %s::%s captures the mock object (%s); "
+			. "this prevents DESTROY-based unmock and will leak past lexical "
+			. "scope (GH #83). Use Test::MockModule->original_for('%s', '%s') "
+			. "or capture \$mock->original('%s') BEFORE calling mock().",
+			$self->{_package}, $name, $varname,
+			$self->{_package}, $name, $name,
+		);
+		return;
+	}
+	return;
 }
 
 # Per-sub stack of live mock layers. Each entry:
@@ -169,6 +202,7 @@ sub _mock {
 		my $code = sub { };
 		if (ref $value && reftype $value eq 'CODE') {
 			$code = $value;
+			$self->_detect_self_capture($code, $name);
 		} elsif (defined $value) {
 			$code = sub {$value};
 		}

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -492,7 +492,7 @@ sub original_for {
 	}
 	no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
 	return \&$sub_name if defined &{$sub_name};
-	return undef;
+	return;
 }
 
 sub unmock {

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -337,12 +337,16 @@ sub _install_layer {
 	}
 }
 
-# Restore the pre-any-mock state for the bottom-most (and now only) layer
-# being popped. Uses the entry's meta_orig when the layer was pushed via
-# meta, otherwise its symbol-table orig coderef.
-sub _restore_pre_mock {
-	my ($self, $sub_name, $name, $entry) = @_;
-	my $meta = _meta_for($self->{_package});
+# Shared restore-from-stack-entry helper. Takes $package explicitly so it
+# can be called both from instance methods (passing $self->{_package}) and
+# class methods (passing the user-provided package). The $entry hashref
+# carries is_meta / meta_orig / orig fields recorded at install time;
+# this routine dispatches to the meta path or the symbol-table path
+# accordingly. Single source of truth for the restore semantics so
+# _restore_pre_mock and reset_for cannot drift apart.
+sub _restore_entry {
+	my ($package, $sub_name, $name, $entry) = @_;
+	my $meta = _meta_for($package);
 	my $can_meta = $meta && !$meta->is_immutable;
 
 	if ($entry->{is_meta} && $can_meta) {
@@ -380,6 +384,13 @@ sub _restore_pre_mock {
 		# between mock and unmock. Fall back to the captured orig coderef.
 		_replace_sub($sub_name, $entry->{orig});
 	}
+}
+
+# Restore the pre-any-mock state for the bottom-most (and now only) layer
+# being popped. Delegates to the shared _restore_entry helper.
+sub _restore_pre_mock {
+	my ($self, $sub_name, $name, $entry) = @_;
+	return _restore_entry($self->{_package}, $sub_name, $name, $entry);
 }
 
 sub noop {
@@ -548,26 +559,7 @@ sub reset_for {
 		my $bottom = $stack->[0];
 		my ($name) = $sub_name =~ /::([^:]+)$/;
 
-		my $meta = _meta_for($package);
-		my $can_meta = $meta && !$meta->is_immutable;
-		if ($bottom->{is_meta} && $can_meta) {
-			my $orig_method = $bottom->{meta_orig};
-			if (defined $orig_method) {
-				my $arg = $meta->isa('Mouse::Meta::Class')
-					? (ref($orig_method) eq 'CODE' ? $orig_method : $orig_method->body)
-					: $orig_method;
-				$meta->add_method($name, $arg);
-			} else {
-				if ($meta->can('remove_method')) {
-					$meta->remove_method($name);
-				} else {
-					delete $meta->{methods}{$name};
-				}
-				_replace_sub($sub_name, $bottom->{orig});
-			}
-		} else {
-			_replace_sub($sub_name, $bottom->{orig});
-		}
+		_restore_entry($package, $sub_name, $name, $bottom);
 
 		delete $mock_subs{$sub_name};
 	}

--- a/t/author-perlcritic.t
+++ b/t/author-perlcritic.t
@@ -1,0 +1,14 @@
+#!perl
+use strict;
+use warnings;
+use Test::More;
+
+# Author/develop test: runs Perl::Critic against lib/ and t/ at the
+# project's --gentle severity. Skipped on machines without
+# Test::Perl::Critic so random CPAN testers do not fail because of an
+# author-only dep.
+eval { require Test::Perl::Critic };
+plan skip_all => 'Test::Perl::Critic not installed (author dep)' if $@;
+
+Test::Perl::Critic->import(-severity => 'gentle');
+all_critic_ok('lib', 't');

--- a/t/closure_capture_warn.t
+++ b/t/closure_capture_warn.t
@@ -4,10 +4,10 @@ use strict;
 use Test::More;
 use Test::MockModule;
 
-package Tgt;
+package Tgt; ## no critic (Modules::RequireFilenameMatchesPackage)
 our $VERSION = 1;
 sub greet { 'hello' }
-package main;
+package main; ## no critic (Modules::RequireFilenameMatchesPackage)
 
 # 1. The buggy pattern: closure captures $mock to call ->original
 {

--- a/t/closure_capture_warn.t
+++ b/t/closure_capture_warn.t
@@ -1,0 +1,85 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::MockModule;
+
+package Tgt;
+our $VERSION = 1;
+sub greet { 'hello' }
+package main;
+
+# 1. The buggy pattern: closure captures $mock to call ->original
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+    my $mock = Test::MockModule->new('Tgt');
+    $mock->mock('greet', sub {
+        return $mock->original('greet')->() . '_x';
+    });
+
+    is(scalar(@warnings), 1, 'one warning emitted for closure-captures-self')
+        or diag explain \@warnings;
+    like($warnings[0], qr/captures the mock object/i,
+        'warning text mentions mock object capture');
+    like($warnings[0], qr/GH ?#?83/i,
+        'warning references GH #83');
+    like($warnings[0], qr/original_for/,
+        'warning recommends original_for');
+}
+
+# 2. The recommended pattern: capture orig before mocking -- no warning
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+    my $mock = Test::MockModule->new('Tgt');
+    my $orig = $mock->original('greet');
+    $mock->mock('greet', sub { $orig->() . '_x' });
+
+    is(scalar(@warnings), 0,
+        'no warning when closure captures only $orig, not $mock')
+        or diag explain \@warnings;
+}
+
+# 3. Plain non-closure mock -- no warning
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+    my $mock = Test::MockModule->new('Tgt');
+    $mock->mock('greet', sub { 'flat' });
+
+    is(scalar(@warnings), 0, 'no warning for non-closure mock')
+        or diag explain \@warnings;
+}
+
+# 4. Scalar value mock (not a coderef at all) -- no warning, no crash
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+    my $mock = Test::MockModule->new('Tgt');
+    $mock->mock('greet', 'plain_scalar');
+
+    is(scalar(@warnings), 0, 'no warning when mocking with a scalar value')
+        or diag explain \@warnings;
+    is(Tgt::greet(), 'plain_scalar', 'scalar mock works');
+}
+
+# 5. Closure captures something OTHER than $mock -- no false positive
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+    my $other = bless {}, 'Some::Other';
+    my $mock = Test::MockModule->new('Tgt');
+    $mock->mock('greet', sub { ref($other) });
+
+    is(scalar(@warnings), 0,
+        'no warning when closure captures unrelated object')
+        or diag explain \@warnings;
+}
+
+done_testing;

--- a/t/gh_83_no_leak.t
+++ b/t/gh_83_no_leak.t
@@ -12,7 +12,7 @@ use Scalar::Util qw(refaddr);
 
 sub make_pkg {
     my ($pkg) = @_;
-    no strict 'refs';
+    no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
     *{"${pkg}::greet"} = sub { 'hello' };
     *{"${pkg}::other"} = sub { 'other' };
     *{"${pkg}::plain"} = sub { 'plain' };
@@ -20,7 +20,7 @@ sub make_pkg {
 
 sub installed_code {
     my ($pkg, $name) = @_;
-    no strict 'refs';
+    no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
     return defined &{"${pkg}::${name}"} ? \&{"${pkg}::${name}"} : undef;
 }
 
@@ -293,7 +293,7 @@ subtest 'V14: define() with original_for' => sub {
     is(scalar(@errors), 0, "no errors from define() leaks: @errors");
     is_deeply \@results, ['new_d1', 'new_d2'],
         'define() each iter sees fresh mock';
-    no strict 'refs';
+    no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
     ok(!defined &{"Tgt_V14::brandnew"},
         'define()d sub removed after scope');
 };

--- a/t/gh_83_no_leak.t
+++ b/t/gh_83_no_leak.t
@@ -1,0 +1,282 @@
+#!/usr/bin/env perl
+# GH #83 regression suite. Each subtest covers a variant of the
+# closure-captures-$mock pattern from the original investigation.
+# After Tasks 2-5 of the implementation plan, every variant has at
+# least one path that no longer leaks.
+use warnings;
+use strict;
+
+use Test::More;
+use Test::MockModule;
+use Scalar::Util qw(refaddr);
+
+sub make_pkg {
+    my ($pkg) = @_;
+    no strict 'refs';
+    *{"${pkg}::greet"} = sub { 'hello' };
+    *{"${pkg}::other"} = sub { 'other' };
+    *{"${pkg}::plain"} = sub { 'plain' };
+}
+
+sub installed_code {
+    my ($pkg, $name) = @_;
+    no strict 'refs';
+    return defined &{"${pkg}::${name}"} ? \&{"${pkg}::${name}"} : undef;
+}
+
+# V1: bare reproducer using original_for (the new pattern)
+subtest 'V1: original_for sidesteps the leak' => sub {
+    make_pkg('Tgt_V1');
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_V1', no_auto => 1);
+        $mock->mock('greet', sub {
+            return Test::MockModule
+                ->original_for('Tgt_V1', 'greet')->() . "_$label";
+        });
+        push @results, Tgt_V1::greet();
+    };
+    $run->('first');
+    $run->('second');
+    is_deeply \@results, ['hello_first', 'hello_second'];
+};
+
+# V2: redefine + original_for
+subtest 'V2: redefine + original_for' => sub {
+    make_pkg('Tgt_V2');
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_V2', no_auto => 1);
+        $mock->redefine('other', sub {
+            return Test::MockModule
+                ->original_for('Tgt_V2', 'other')->() . "_$label";
+        });
+        push @results, Tgt_V2::other();
+    };
+    $run->('a');
+    $run->('b');
+    is_deeply \@results, ['other_a', 'other_b'];
+};
+
+# V3: explicit unmock_all (workaround already worked pre-fix; regression guard)
+subtest 'V3: explicit unmock_all still works' => sub {
+    make_pkg('Tgt_V3');
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_V3', no_auto => 1);
+        $mock->mock('plain', sub {
+            return $mock->original('plain')->() . "_$label";
+        });
+        push @results, Tgt_V3::plain();
+        $mock->unmock_all;
+    };
+    $run->('x');
+    $run->('y');
+    is_deeply \@results, ['plain_x', 'plain_y'];
+};
+
+# V4: capture orig BEFORE mock (POD workaround; regression guard)
+subtest 'V4: capture orig before mock' => sub {
+    make_pkg('Tgt_V4');
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_V4', no_auto => 1);
+        my $orig = $mock->original('greet');
+        $mock->mock('greet', sub { $orig->() . "_$label" });
+        push @results, Tgt_V4::greet();
+    };
+    $run->('w1');
+    $run->('w2');
+    is_deeply \@results, ['hello_w1', 'hello_w2'];
+};
+
+# V5: closure for is_mocked check via original_for-style class method
+#     (no $mock capture)
+subtest 'V5: is_mocked replaced with class-method check' => sub {
+    make_pkg('Tgt_V5');
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_V5', no_auto => 1);
+        $mock->mock('greet', sub {
+            # If user truly needs to know, they can poke %mock_subs via
+            # the registry -- but for the common case, just don't capture.
+            return "mocked_$label";
+        });
+        push @results, Tgt_V5::greet();
+    };
+    $run->('m1');
+    $run->('m2');
+    is_deeply \@results, ['mocked_m1', 'mocked_m2'];
+};
+
+# V6: nested scope cleanup using original_for
+subtest 'V6: nested scope cleanup' => sub {
+    make_pkg('Tgt_V6');
+    {
+        my $mock = Test::MockModule->new('Tgt_V6', no_auto => 1);
+        $mock->mock('greet', sub {
+            return Test::MockModule->original_for('Tgt_V6', 'greet')->() . '_inner';
+        });
+        is(Tgt_V6::greet(), 'hello_inner', 'inside scope: mock active');
+    }
+    is(Tgt_V6::greet(), 'hello', 'after scope: mock undone');
+};
+
+# V7: 5 iterations using original_for
+subtest 'V7: 5 iterations' => sub {
+    make_pkg('Tgt_V7');
+    my @results;
+    for my $i (1..5) {
+        my $mock = Test::MockModule->new('Tgt_V7', no_auto => 1);
+        $mock->mock('greet', sub {
+            return Test::MockModule
+                ->original_for('Tgt_V7', 'greet')->() . "_i$i";
+        });
+        push @results, Tgt_V7::greet();
+    }
+    is_deeply \@results,
+        ['hello_i1', 'hello_i2', 'hello_i3', 'hello_i4', 'hello_i5'];
+};
+
+# V8: indirect capture via arrayref using original_for
+subtest 'V8: arrayref capture' => sub {
+    make_pkg('Tgt_V8');
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_V8', no_auto => 1);
+        my $box  = ['Tgt_V8', 'greet'];
+        $mock->mock('greet', sub {
+            return Test::MockModule->original_for(@$box)->() . "_$label";
+        });
+        push @results, Tgt_V8::greet();
+    };
+    $run->('q1');
+    $run->('q2');
+    is_deeply \@results, ['hello_q1', 'hello_q2'];
+};
+
+# V9: user-level Scalar::Util::weaken (workaround already worked; guard)
+subtest 'V9: user-level weaken still works' => sub {
+    make_pkg('Tgt_V9');
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_V9', no_auto => 1);
+        my $weak = $mock;
+        Scalar::Util::weaken($weak);
+        $mock->mock('greet', sub {
+            return $weak ? $weak->original('greet')->() . "_$label" : 'weakgone';
+        });
+        push @results, Tgt_V9::greet();
+    };
+    $run->('z1');
+    $run->('z2');
+    is_deeply \@results, ['hello_z1', 'hello_z2'];
+};
+
+# V10: symbol-table refaddr probe
+subtest 'V10: symbol table restored' => sub {
+    make_pkg('Tgt_V10');
+    my $orig_addr = refaddr(installed_code('Tgt_V10', 'greet'));
+    {
+        my $mock = Test::MockModule->new('Tgt_V10', no_auto => 1);
+        $mock->mock('greet', sub {
+            return Test::MockModule
+                ->original_for('Tgt_V10', 'greet')->() . '_internal';
+        });
+        is(Tgt_V10::greet(), 'hello_internal', 'mock active inside');
+        isnt(refaddr(installed_code('Tgt_V10', 'greet')), $orig_addr,
+            'symbol table holds mock during scope');
+    }
+    is(refaddr(installed_code('Tgt_V10', 'greet')), $orig_addr,
+        'symbol table restored after scope (GH #83 fix proof)');
+    is(Tgt_V10::greet(), 'hello', 'callable result restored');
+};
+
+# V11: chained no-lexical (regression guard)
+subtest 'V11: chained no-lexical' => sub {
+    make_pkg('Tgt_V11');
+    Test::MockModule->new('Tgt_V11', no_auto => 1)
+        ->mock(greet => sub { 'pure_chain' });
+    is(Tgt_V11::greet(), 'hello',
+        'chained mock with no lexical: object dies, mock undone');
+};
+
+# V12: literal reporter pattern using original_for
+subtest 'V12: reporter pattern with original_for' => sub {
+    package Tgt_V12;
+    our $VERSION = 1;
+    sub greet { 'hello' }
+    package main;
+
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_V12', no_auto => 1);
+        $mock->mock('greet', sub {
+            return Test::MockModule
+                ->original_for('Tgt_V12', 'greet')->() . "_$label";
+        });
+        push @results, Tgt_V12::greet();
+    };
+    $run->('first');
+    $run->('second');
+    is_deeply \@results, ['hello_first', 'hello_second'];
+};
+
+# V13: refaddr drift across iterations
+subtest 'V13: distinct installed coderefs across iterations' => sub {
+    make_pkg('Tgt_V13');
+    my @addrs;
+    for my $i (1..3) {
+        my $mock = Test::MockModule->new('Tgt_V13', no_auto => 1);
+        $mock->mock('greet', sub {
+            return Test::MockModule
+                ->original_for('Tgt_V13', 'greet')->() . "_$i";
+        });
+        push @addrs, refaddr(installed_code('Tgt_V13', 'greet'));
+    }
+    my %u; @u{@addrs} = ();
+    is(scalar(keys %u), 3,
+        'three distinct installed coderefs (got ' . join(',', @addrs) . ')');
+};
+
+# V14: define() variant using original_for
+subtest 'V14: define() with original_for' => sub {
+    package Tgt_V14;
+    our $VERSION = 1;
+    sub existing { 'exists' }
+    package main;
+
+    my @results;
+    my @errors;
+    my $run = sub {
+        my ($label) = @_;
+        my $rv = eval {
+            my $mock = Test::MockModule->new('Tgt_V14', no_auto => 1);
+            $mock->define(brandnew => sub {
+                # No $mock capture
+                return "new_$label";
+            });
+            push @results, Tgt_V14::brandnew();
+            1;
+        };
+        push @errors, $@ if !$rv;
+    };
+    $run->('d1');
+    $run->('d2');
+    is(scalar(@errors), 0, "no errors from define() leaks: @errors");
+    is_deeply \@results, ['new_d1', 'new_d2'],
+        'define() each iter sees fresh mock';
+    no strict 'refs';
+    ok(!defined &{"Tgt_V14::brandnew"},
+        'define()d sub removed after scope');
+};
+
+done_testing;

--- a/t/gh_83_no_leak.t
+++ b/t/gh_83_no_leak.t
@@ -62,6 +62,10 @@ subtest 'V2: redefine + original_for' => sub {
 
 # V3: explicit unmock_all (workaround already worked pre-fix; regression guard)
 subtest 'V3: explicit unmock_all still works' => sub {
+    # Closure intentionally captures $mock (the GH #83 pattern) to verify
+    # that explicit unmock_all bypasses the leak. Suppress the resulting
+    # _detect_self_capture warning so it doesn't pollute prove output.
+    local $SIG{__WARN__} = sub {};
     make_pkg('Tgt_V3');
     my @results;
     my $run = sub {
@@ -163,6 +167,10 @@ subtest 'V8: arrayref capture' => sub {
 
 # V9: user-level Scalar::Util::weaken (workaround already worked; guard)
 subtest 'V9: user-level weaken still works' => sub {
+    # Closure captures $weak (a weakened ref to $mock). Same refaddr as
+    # $mock, so _detect_self_capture warns even though the user has
+    # already mitigated. Suppress to keep prove output clean.
+    local $SIG{__WARN__} = sub {};
     make_pkg('Tgt_V9');
     my @results;
     my $run = sub {

--- a/t/gh_83_no_leak.t
+++ b/t/gh_83_no_leak.t
@@ -230,9 +230,10 @@ subtest 'V12: reporter pattern with original_for' => sub {
     is_deeply \@results, ['hello_first', 'hello_second'];
 };
 
-# V13: refaddr drift across iterations
-subtest 'V13: distinct installed coderefs across iterations' => sub {
+# V13: refaddr drift across iterations + post-loop symbol-table restoration
+subtest 'V13: distinct coderefs and symbol table restored' => sub {
     make_pkg('Tgt_V13');
+    my $orig_addr = refaddr(installed_code('Tgt_V13', 'greet'));
     my @addrs;
     for my $i (1..3) {
         my $mock = Test::MockModule->new('Tgt_V13', no_auto => 1);
@@ -242,9 +243,19 @@ subtest 'V13: distinct installed coderefs across iterations' => sub {
         });
         push @addrs, refaddr(installed_code('Tgt_V13', 'greet'));
     }
+    # Address-distinctness is informational -- some allocators reuse
+    # memory between iterations, so this is not a load-bearing assertion.
+    # The actual leak signal is the post-loop restoration check below.
     my %u; @u{@addrs} = ();
-    is(scalar(keys %u), 3,
-        'three distinct installed coderefs (got ' . join(',', @addrs) . ')');
+    cmp_ok(scalar(keys %u), '>=', 1,
+        'at least one distinct installed coderef seen (got '
+        . join(',', @addrs) . ')');
+
+    # The real test: after all three iterations, the symbol table must
+    # be back to the original sub. If any mock leaked, this fails.
+    is(refaddr(installed_code('Tgt_V13', 'greet')), $orig_addr,
+        'symbol table restored after all iterations (no leak)');
+    is(Tgt_V13::greet(), 'hello', 'callable result restored');
 };
 
 # V14: define() variant using original_for

--- a/t/original_for.t
+++ b/t/original_for.t
@@ -1,0 +1,81 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::MockModule;
+use Scalar::Util qw(refaddr);
+
+package Tgt::OriginalFor;
+our $VERSION = 1;
+sub greet { 'hello' }
+sub other { 'other' }
+package main;
+
+# 1. Returns the actual sub when not mocked
+{
+    my $code = Test::MockModule->original_for('Tgt::OriginalFor', 'greet');
+    is(ref($code), 'CODE', 'returns a coderef when sub is not mocked');
+    is($code->(), 'hello', '... that calls the real implementation');
+}
+
+# 2. Returns the truly-original (not the active mock) when mocked
+{
+    my $mock = Test::MockModule->new('Tgt::OriginalFor');
+    $mock->mock('greet', sub { 'mocked' });
+
+    is(Tgt::OriginalFor::greet(), 'mocked', 'symbol table now holds the mock');
+
+    my $orig = Test::MockModule->original_for('Tgt::OriginalFor', 'greet');
+    is($orig->(), 'hello',
+        'original_for returns the pre-mock implementation, not the mock');
+}
+
+# 3. The recommended GH #83-safe pattern: closure captures strings, not $mock
+{
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt::OriginalFor', no_auto => 1);
+        $mock->mock('greet', sub {
+            # No $mock capture -- only the package and sub name strings
+            return Test::MockModule
+                ->original_for('Tgt::OriginalFor', 'greet')->() . "_$label";
+        });
+        push @results, Tgt::OriginalFor::greet();
+    };
+    $run->('first');
+    $run->('second');
+    is_deeply \@results, ['hello_first', 'hello_second'],
+        'original_for pattern does not leak past lexical scope (GH #83 fix)';
+}
+
+# 4. Stacked mocks: original_for still returns the truly-original
+{
+    my $m1 = Test::MockModule->new('Tgt::OriginalFor');
+    $m1->mock('other', sub { 'L1' });
+    {
+        my $m2 = Test::MockModule->new('Tgt::OriginalFor');
+        $m2->mock('other', sub { 'L2' });
+        is(Tgt::OriginalFor::other(), 'L2', 'top mock wins');
+        my $orig = Test::MockModule->original_for('Tgt::OriginalFor', 'other');
+        is($orig->(), 'other',
+            'original_for returns pre-any-mock impl, not the layer below');
+    }
+}
+
+# 5. Invalid args croak
+{
+    eval { Test::MockModule->original_for('', 'foo') };
+    like($@, qr/Invalid package name/, 'empty package croaks');
+
+    eval { Test::MockModule->original_for('Tgt::OriginalFor', '') };
+    like($@, qr/valid function name/i, 'empty sub name croaks');
+}
+
+# 6. Looking up a sub that doesn't exist returns undef without crashing
+{
+    my $code = Test::MockModule->original_for('Tgt::OriginalFor', 'nonexistent');
+    is($code, undef, 'returns undef for nonexistent sub');
+}
+
+done_testing;

--- a/t/original_for.t
+++ b/t/original_for.t
@@ -78,4 +78,23 @@ package main;
     is($code, undef, 'returns undef for nonexistent sub');
 }
 
+# 7. define()'d subs: original_for must return undef, not the live mock.
+#    The bottom-of-stack orig is undef in this case (the sub had no
+#    pre-mock implementation). Falling through to \&{$sub_name} would
+#    return the active mock and cause infinite recursion if the user's
+#    closure called original_for to "wrap" itself.
+{
+    package Tgt::DefineOnly;
+    our $VERSION = 1;
+    package main;
+
+    my $mock = Test::MockModule->new('Tgt::DefineOnly');
+    $mock->define('brandnew', sub { 'mocked' });
+    is(Tgt::DefineOnly::brandnew(), 'mocked', 'define()d sub callable');
+
+    my $orig = Test::MockModule->original_for('Tgt::DefineOnly', 'brandnew');
+    is($orig, undef,
+        'original_for returns undef for define()d sub (no pre-mock impl, no fall-through to live mock)');
+}
+
 done_testing;

--- a/t/original_for.t
+++ b/t/original_for.t
@@ -5,11 +5,11 @@ use Test::More;
 use Test::MockModule;
 use Scalar::Util qw(refaddr);
 
-package Tgt::OriginalFor;
+package Tgt::OriginalFor; ## no critic (Modules::RequireFilenameMatchesPackage)
 our $VERSION = 1;
 sub greet { 'hello' }
 sub other { 'other' }
-package main;
+package main; ## no critic (Modules::RequireFilenameMatchesPackage)
 
 # 1. Returns the actual sub when not mocked
 {

--- a/t/reset_for.t
+++ b/t/reset_for.t
@@ -5,11 +5,11 @@ use Test::More;
 use Test::MockModule;
 use Scalar::Util qw(refaddr);
 
-package Tgt::ResetFor;
+package Tgt::ResetFor; ## no critic (Modules::RequireFilenameMatchesPackage)
 our $VERSION = 1;
 sub greet { 'hello' }
 sub other { 'other' }
-package main;
+package main; ## no critic (Modules::RequireFilenameMatchesPackage)
 
 # 1. reset_for restores all subs in the named package
 {

--- a/t/reset_for.t
+++ b/t/reset_for.t
@@ -3,6 +3,7 @@ use strict;
 
 use Test::More;
 use Test::MockModule;
+use Scalar::Util qw(refaddr);
 
 package Tgt::ResetFor;
 our $VERSION = 1;
@@ -85,6 +86,23 @@ package main;
 
     eval { Test::MockModule->reset_for('123Invalid') };
     like($@, qr/Invalid package name/, 'numeric-leading package name croaks');
+}
+
+# 6. reset_for clears the singleton registry too
+{
+    my $first = Test::MockModule->new('Tgt::ResetFor', singleton => 1);
+    $first->mock('greet', sub { 'first_singleton' });
+    is(Tgt::ResetFor::greet(), 'first_singleton', 'first singleton mock active');
+
+    Test::MockModule->reset_for('Tgt::ResetFor');
+
+    # After reset_for, the singleton entry should be cleared too.
+    # A subsequent singleton => 1 call should NOT return the same object.
+    my $second = Test::MockModule->new('Tgt::ResetFor', singleton => 1);
+    isnt(Scalar::Util::refaddr($first), Scalar::Util::refaddr($second),
+        'reset_for invalidates the singleton registry entry');
+    is(Tgt::ResetFor::greet(), 'hello',
+        'sub still restored after reset_for');
 }
 
 done_testing;

--- a/t/reset_for.t
+++ b/t/reset_for.t
@@ -1,0 +1,90 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::MockModule;
+
+package Tgt::ResetFor;
+our $VERSION = 1;
+sub greet { 'hello' }
+sub other { 'other' }
+package main;
+
+# 1. reset_for restores all subs in the named package
+{
+    my $mock = Test::MockModule->new('Tgt::ResetFor');
+    $mock->mock('greet', sub { 'mocked_greet' });
+    $mock->mock('other', sub { 'mocked_other' });
+
+    is(Tgt::ResetFor::greet(), 'mocked_greet', 'greet mocked');
+    is(Tgt::ResetFor::other(), 'mocked_other', 'other mocked');
+
+    Test::MockModule->reset_for('Tgt::ResetFor');
+
+    is(Tgt::ResetFor::greet(), 'hello', 'greet restored after reset_for');
+    is(Tgt::ResetFor::other(), 'other', 'other restored after reset_for');
+}
+
+# 2. reset_for unsticks the GH #83 leak pattern
+{
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt::ResetFor', no_auto => 1);
+        $mock->mock('greet', sub {
+            return $mock->original('greet')->() . "_$label";
+        });
+        push @results, Tgt::ResetFor::greet();
+        # Explicit teardown bypasses DESTROY-leak
+        Test::MockModule->reset_for('Tgt::ResetFor');
+    };
+    $run->('a');
+    $run->('b');
+    is_deeply \@results, ['hello_a', 'hello_b'],
+        'reset_for fixes GH #83 leak when called explicitly';
+}
+
+# 3. reset_for is scoped to the named package only
+{
+    package Other::ResetFor;
+    our $VERSION = 1;
+    sub greet { 'other_pkg' }
+    package main;
+
+    my $a = Test::MockModule->new('Tgt::ResetFor');
+    my $b = Test::MockModule->new('Other::ResetFor');
+    $a->mock('greet', sub { 'A_mocked' });
+    $b->mock('greet', sub { 'B_mocked' });
+
+    Test::MockModule->reset_for('Tgt::ResetFor');
+
+    is(Tgt::ResetFor::greet(), 'hello',     'A package reset');
+    is(Other::ResetFor::greet(), 'B_mocked', 'B package untouched');
+
+    Test::MockModule->reset_for('Other::ResetFor');
+    is(Other::ResetFor::greet(), 'other_pkg', 'B package reset on second call');
+}
+
+# 4. reset_for on a package with no mocks is a no-op (no croak)
+{
+    package Untouched::ResetFor;
+    our $VERSION = 1;
+    sub thing { 'untouched' }
+    package main;
+
+    eval { Test::MockModule->reset_for('Untouched::ResetFor') };
+    is($@, '', 'reset_for on un-mocked package does not croak');
+    is(Untouched::ResetFor::thing(), 'untouched',
+        '... and leaves the sub alone');
+}
+
+# 5. reset_for with invalid package name croaks
+{
+    eval { Test::MockModule->reset_for('') };
+    like($@, qr/Invalid package name/, 'empty package name croaks');
+
+    eval { Test::MockModule->reset_for('123Invalid') };
+    like($@, qr/Invalid package name/, 'numeric-leading package name croaks');
+}
+
+done_testing;

--- a/t/reset_for.t
+++ b/t/reset_for.t
@@ -28,6 +28,10 @@ package main;
 
 # 2. reset_for unsticks the GH #83 leak pattern
 {
+    # Closure intentionally captures $mock (the GH #83 pattern) to verify
+    # that explicit reset_for bypasses the leak. Suppress the resulting
+    # _detect_self_capture warning so it doesn't pollute prove output.
+    local $SIG{__WARN__} = sub {};
     my @results;
     my $run = sub {
         my ($label) = @_;

--- a/t/singleton_opt_in.t
+++ b/t/singleton_opt_in.t
@@ -71,4 +71,28 @@ package main;
         'second singleton call returns the singleton');
 }
 
+# 6. _detect_self_capture warning is suppressed under singleton mode
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+    package Tgt::SingletonNoWarn;
+    our $VERSION = 1;
+    sub greet { 'hi' }
+    package main;
+
+    my $mock = Test::MockModule->new(
+        'Tgt::SingletonNoWarn', no_auto => 1, singleton => 1
+    );
+    $mock->mock('greet', sub {
+        # Closure captures $mock -- would normally trigger GH #83 warning,
+        # but singleton mode is the documented workaround so the warning
+        # would be noise.
+        return $mock->original('greet')->() . '_x';
+    });
+    is(scalar(@warnings), 0,
+        'no GH #83 warning when singleton mode is used (documented workaround)')
+        or diag explain \@warnings;
+}
+
 done_testing;

--- a/t/singleton_opt_in.t
+++ b/t/singleton_opt_in.t
@@ -1,0 +1,74 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::MockModule;
+use Scalar::Util qw(refaddr);
+
+package Tgt::SingletonOptIn;
+our $VERSION = 1;
+sub greet { 'hello' }
+package main;
+
+# 1. Default behavior unchanged: distinct objects per call (GH #48)
+{
+    my $a = Test::MockModule->new('Tgt::SingletonOptIn');
+    my $b = Test::MockModule->new('Tgt::SingletonOptIn');
+    isnt(refaddr($a), refaddr($b),
+        'default new(): distinct objects (GH #48 preserved)');
+}
+
+# 2. singleton => 1: same object for same package
+{
+    my $a = Test::MockModule->new('Tgt::SingletonOptIn', singleton => 1);
+    my $b = Test::MockModule->new('Tgt::SingletonOptIn', singleton => 1);
+    is(refaddr($a), refaddr($b),
+        'singleton => 1: same object across repeated new() calls');
+}
+
+# 3. singleton => 1 fixes the GH #83 reproducer pattern
+{
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new(
+            'Tgt::SingletonOptIn', no_auto => 1, singleton => 1
+        );
+        $mock->mock('greet', sub {
+            return $mock->original('greet')->() . "_$label";
+        });
+        push @results, Tgt::SingletonOptIn::greet();
+    };
+    $run->('first');
+    $run->('second');
+    is_deeply \@results, ['hello_first', 'hello_second'],
+        'singleton => 1 fixes GH #83 reproducer';
+}
+
+# 4. singleton scope is per-package (different packages = different objects)
+{
+    package Other::SingletonOptIn;
+    our $VERSION = 1;
+    sub greet { 'other' }
+    package main;
+
+    my $a = Test::MockModule->new('Tgt::SingletonOptIn', singleton => 1);
+    my $b = Test::MockModule->new('Other::SingletonOptIn', singleton => 1);
+    isnt(refaddr($a), refaddr($b),
+        'singleton scope is per-package');
+}
+
+# 5. singleton/non-singleton calls for the same package don't conflict
+#    (non-singleton call always gets a fresh object)
+{
+    my $s = Test::MockModule->new('Tgt::SingletonOptIn', singleton => 1);
+    my $d = Test::MockModule->new('Tgt::SingletonOptIn');
+    isnt(refaddr($s), refaddr($d),
+        'non-singleton new() always returns fresh object');
+
+    my $s2 = Test::MockModule->new('Tgt::SingletonOptIn', singleton => 1);
+    is(refaddr($s), refaddr($s2),
+        'second singleton call returns the singleton');
+}
+
+done_testing;

--- a/t/singleton_opt_in.t
+++ b/t/singleton_opt_in.t
@@ -5,10 +5,10 @@ use Test::More;
 use Test::MockModule;
 use Scalar::Util qw(refaddr);
 
-package Tgt::SingletonOptIn;
+package Tgt::SingletonOptIn; ## no critic (Modules::RequireFilenameMatchesPackage)
 our $VERSION = 1;
 sub greet { 'hello' }
-package main;
+package main; ## no critic (Modules::RequireFilenameMatchesPackage)
 
 # 1. Default behavior unchanged: distinct objects per call (GH #48)
 {


### PR DESCRIPTION
Closes #83.

## The bug

`Test::MockModule` closures that call `$mock->original(...)` capture `$mock`. The captured strong reference pins refcount above zero, `DESTROY` never fires, `unmock_all` is never called, and the mock leaks past lexical scope into subsequent tests.

```perl
sub run {
    my ($label) = @_;
    my $mock = Test::MockModule->new('Target', no_auto => 1);
    $mock->mock('greet', sub {
        return $mock->original('greet')->() . "_$label";  # captures $mock
    });
    is(Target::greet(), "hello_$label", $label);
}

run('first');   # passes
run('second');  # FAILS in 0.181-0.184: got 'hello_first_second'
```

Regression since v0.181 ([5fad57c](https://github.com/geofffranks/test-mockmodule/commit/5fad57c) — GH #48 distinct-objects-per-`new()`). The pre-0.180 singleton sentinel was the only thing masking the issue; once `new()` started returning fresh objects, `DESTROY` became the sole cleanup mechanism and the closure-capture pattern broke it.

## Why the problem is deeper than the issue describes

The reporter described it as a circular reference: `$self → {_mocked}{sub} → coderef → $self`. **That cycle does not exist** — `$self->{_mocked}{$name}` is a flag (`1`), not the coderef. The actual shape is a **non-cyclic but unreachable-by-`DESTROY`** chain: the file-scoped `%mock_subs` registry strongly holds `$code` (the user's installed closure), and `$code` strongly holds `$self` via Perl's pad-slot capture. There's no cycle for Perl's GC to detect — `$self` just stays reachable from a global root.

Consequence: the reporter's primary suggested fix (weak `owner` field on `%mock_subs` entries) **doesn't work**. Verified empirically — adding `weaken($weak_self)` to the entry has no effect, because the entry never directly held `$self` to begin with.

Worse, **PadWalker pad-slot weakening also doesn't work**. Verified empirically: pad slots returned by `closed_over` are aliased to the parent's lexical (Perl closures share the SV). Calling `weaken($$slot)` from inside `_mock()` immediately weakens the user's outer `$mock` lexical, killing the object before their test code can run. This was the proposed transparent fix; it's structurally impossible.

This means **any implementation of "distinct objects + auto-cleanup on scope exit via `DESTROY`" will hit this bug whenever the user's closure captures the mock object.** The trap is fundamental to combining GH #48's distinct-objects feature with the documented `$mock->original` pattern. Can't be silently fixed; only worked around.

## The fix: detect, warn, escape

Four orthogonal additive changes — none reverse GH #48:

### 1. Detection warning at install time (`_detect_self_capture`)

`PadWalker::closed_over` walks the user's coderef pad at `_mock()` time. If any captured slot's `refaddr` matches `$self`, `carp` once with a clear migration message:

```
Test::MockModule: closure for Target::greet captures the mock object ($mock);
this prevents DESTROY-based unmock and will leak past lexical scope (GH #83).
Use Test::MockModule->original_for('Target', 'greet') or capture
$mock->original('greet') BEFORE calling mock().
```

Pure diagnostic — never modifies the closure. Suppressed under `singleton => 1` (see below) since that mode is itself a deliberate workaround.

### 2. New idiomatic pattern: `Test::MockModule->original_for($pkg, $sub)`

Class-method counterpart to `$mock->original`. Returns the truly-original sub from the `%mock_subs` registry (or live sub if not mocked). Lets the closure capture only strings:

```perl
my $mock = Test::MockModule->new('Target');
$mock->mock('greet', sub {
    Test::MockModule->original_for('Target', 'greet')->(@_) . '_x';
});
```

`$mock` can be GC'd at scope end → `DESTROY` fires → `unmock_all` runs.

### 3. Opt-in singleton mode: `new($pkg, singleton => 1)`

Restores pre-0.180 per-package singleton behavior as an escape hatch for existing test code that can't easily be rewritten. Per-package weak registry; subsequent `new()` calls return the same `$mock`, so `mock()` overwrites the leaked closure rather than stacking. Default behavior unchanged — fresh object per call.

### 4. Class-level teardown: `Test::MockModule->reset_for($pkg)`

Walks `%mock_subs` and restores every mocked sub in `$pkg`, regardless of which `$mock` owns it. Also clears the singleton registry, so pairing it with `singleton => 1` gives a guaranteed clean slate for the next test.

## Existing workarounds still work

- **Capture orig before `mock`** (was the existing POD recommendation): `my $orig = $mock->original('foo'); $mock->mock(foo => sub { $orig->(@_) })`
- **User-level `Scalar::Util::weaken`**: weaken a copy of `$mock` before the closure references it
- **Chained `new->mock`** with no lexical (object dies immediately, `DESTROY` fires synchronously)

## Caveats

- Singleton registry is **process-global per-package**. Tests sharing a process can see each other's singletons. Pair `singleton => 1` with `reset_for($pkg)` in teardown if you need strict isolation.
- After `reset_for($pkg)`, any `$mock` that owned cleared entries has stale internal state. Don't call `unmock`/`unmock_all` on those `$mock`s afterward.
- New runtime dep: **PadWalker** (XS, used purely for warning detection). Perl floor bumped from 5.6.0 → 5.8.1 (PadWalker requirement; 5.8.1 is from 2003).

## Test plan

- [x] Full suite: 385 tests across 30 files, all pass (was 330 across 25 files on `main`)
- [x] New test files exercise each new API (`t/closure_capture_warn.t`, `t/singleton_opt_in.t`, `t/reset_for.t`, `t/original_for.t`)
- [x] 14-variant integration suite (`t/gh_83_no_leak.t`) — every variant of the closure-capture pattern from the original investigation, demonstrating that `original_for` (or one of the documented workarounds) closes each one. V10 specifically asserts `\&Pkg::sub` refaddr pre/post scope as direct evidence of symbol-table restoration.
- [x] Control: the unmodified GH #83 reproducer **still leaks** (we did NOT silently fix it) AND emits the new diagnostic warning twice during execution. Confirmed manually.
- [x] `t/multiple_objects.t` (the GH #48 distinct-objects regression guard) passes unchanged — default behavior preserved.
- [x] All Moose/Mouse tests pass — `_restore_entry` helper extracted from `_restore_pre_mock` is shared by both `unmock` and `reset_for`, so meta-class restoration logic has a single source of truth.
