### PR TITLE
Fix/gh 83 revert distinct default

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -22,17 +22,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - uses: shogo82148/actions-setup-perl@v1
       - run: perl -V
+      # Reads ALL deps (configure / runtime / test) from META.json /
+      # Build.PL. cpanm honors configure_requires automatically, so
+      # Module::Build gets pulled in before perl Build.PL runs.
+      # Single source of truth -- adding a new dep to Build.PL picks
+      # up here without a workflow edit. Test::Perl::Critic is an
+      # author-only dep used by t/author-perlcritic.t; installed
+      # explicitly so the lint test runs in CI under AUTHOR_TESTING=1.
       - name: install dependencies
-        uses: perl-actions/install-with-cpm@v2
-        with:
-          install: |
-            Carp
-            Module::Build
-            Scalar::Util
-            SUPER
-            Test::More
-            Test::Warnings
+        run: |
+          cpanm --installdeps --notest .
+          cpanm --notest Test::Perl::Critic Perl::Critic
       - run: perl Build.PL
       - run: ./Build
       - run: ./Build test
@@ -72,6 +74,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: perl -V
+      # perldocker/perl-tester images ship with cpanm + Module::Build
+      # preinstalled, so no bootstrap step needed. Same `cpanm
+      # --installdeps` pattern as the ubuntu job; reads Build.PL
+      # directly. Avoids dep-list duplication between workflow + Build.PL.
+      - name: install dependencies
+        run: cpanm --installdeps --notest .
       - run: perl Build.PL
       - run: ./Build
       - run: ./Build test

--- a/Build.PL
+++ b/Build.PL
@@ -11,7 +11,9 @@ my $class = Module::Build->subclass(
 	code => <<'CRITIC_ACTION',
 sub ACTION_critic {
 	my $self = shift;
-	require Test::Perl::Critic;
+	eval { require Test::Perl::Critic; 1 }
+		or die "./Build critic requires Test::Perl::Critic. "
+		     . "Install it with: cpanm Test::Perl::Critic\n";
 	Test::Perl::Critic->import(-severity => 'gentle');
 	Test::Perl::Critic::all_critic_ok('lib', 't');
 }

--- a/Build.PL
+++ b/Build.PL
@@ -2,7 +2,23 @@ use strict;
 use warnings;
 use Module::Build;
 
-my $builder = Module::Build->new(
+# Subclass to add a `./Build critic` action that runs Perl::Critic
+# against lib/ and t/ at the project's --gentle severity. Same check
+# as the author-mode test in t/author-perlcritic.t -- this just lets
+# you invoke it standalone without running the full test suite.
+my $class = Module::Build->subclass(
+	class => 'Test::MockModule::Builder',
+	code => <<'CRITIC_ACTION',
+sub ACTION_critic {
+	my $self = shift;
+	require Test::Perl::Critic;
+	Test::Perl::Critic->import(-severity => 'gentle');
+	Test::Perl::Critic::all_critic_ok('lib', 't');
+}
+CRITIC_ACTION
+);
+
+my $builder = $class->new(
 	module_name         => 'Test::MockModule',
 	create_license      => 1,
 	license             => 'perl',

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -86,15 +86,19 @@ sub new {
 		croak "Invalid package name $package";
 	}
 
-	if (!$args{distinct} && $singleton{$package}) {
-		TRACE("Reusing singleton MockModule object for $package");
-		return $singleton{$package};
-	}
-
+	# Auto-load the package BEFORE consulting the singleton cache.
+	# Otherwise a singleton seeded by an earlier `no_auto => 1` caller
+	# would silently deny later default-mode callers the module load
+	# they expect from `new()` (Koan-Bot review on PR #85).
 	unless ($package eq "CORE::GLOBAL" || $package eq 'main' || $args{no_auto} || ${"$package\::VERSION"}) {
 		(my $load_package = "$package.pm") =~ s{::}{/}g;
 		TRACE("$package is empty, loading $load_package");
 		require $load_package;
+	}
+
+	if (!$args{distinct} && $singleton{$package}) {
+		TRACE("Reusing singleton MockModule object for $package");
+		return $singleton{$package};
 	}
 
 	TRACE("Creating MockModule object for $package");

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -2,7 +2,7 @@ package Test::MockModule;
 use warnings;
 use strict qw/subs vars/;
 use vars qw/$VERSION/;
-use Scalar::Util qw/reftype refaddr/;
+use Scalar::Util qw/reftype refaddr weaken/;
 use Carp;
 use SUPER;
 # This is now auto-updated at release time by the github action
@@ -67,6 +67,16 @@ sub _strict_mode {
 #                way as orig, so the bottom-of-stack restore can use the
 #                correct pre-any-mock meta state.
 my %mock_subs;
+
+# Per-package weak registry: keeps the singleton-per-package behavior
+# that was the default prior to v0.181 (and the documented contract for
+# the `$mock->original` from-inside-closure pattern). new() returns
+# the existing object for a package if one is alive; weak ref so a
+# cleanly-destroyed mock releases the slot naturally. Pass
+# `distinct => 1` to opt out and get a fresh object per call (the
+# v0.181+ GH #48 behavior).
+my %singleton;
+
 sub new {
 	my ($class, $package, %args) = @_;
 
@@ -74,6 +84,11 @@ sub new {
 	unless (_valid_package($package)) {
 		$package = 'undef' unless defined $package;
 		croak "Invalid package name $package";
+	}
+
+	if (!$args{distinct} && $singleton{$package}) {
+		TRACE("Reusing singleton MockModule object for $package");
+		return $singleton{$package};
 	}
 
 	unless ($package eq "CORE::GLOBAL" || $package eq 'main' || $args{no_auto} || ${"$package\::VERSION"}) {
@@ -87,6 +102,12 @@ sub new {
 		_package => $package,
 		_mocked  => {},
 	}, $class;
+
+	if (!$args{distinct}) {
+		$singleton{$package} = $self;
+		weaken($singleton{$package});
+	}
+
 	return $self;
 }
 

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -743,26 +743,41 @@ increases over time.
 
 =item new($package[, %options])
 
-Returns a new object that will mock subroutines in the specified C<$package>.
-Each call to C<new()> returns a distinct object, even for the same package.
-Multiple mock objects can coexist for the same package, each tracking its own
-mocked subroutines independently. When a mock object is destroyed (or goes out
-of scope), only the subroutines it mocked are restored.
+Returns a singleton-per-package mock object. Two calls to
+C<< Test::MockModule->new('Foo') >> return the same object as long as the
+first one is still alive; this preserves the long-standing pre-v0.181
+contract that the documented C<< $mock->original >> from-inside-closure
+pattern depends on (see GH #83).
 
-If two objects mock the same subroutine, the most recent C<mock>/C<redefine>
-call wins regardless of stack position. When a mock object is destroyed (or
-unmocked), the layer below it on the stack is reactivated. When all mock
-objects for a subroutine are destroyed, the original subroutine is restored.
+Pass C<< distinct => 1 >> to opt into the v0.181 GH #48 semantics --
+each call returns a fresh object, multiple mock objects coexist on the
+same package, and the per-sub stack handles multi-mock layering:
 
-Note: prior to v0.180.x, C<new()> returned the same object on subsequent calls
-for an already-mocked package. Tests relying on that singleton behavior should
-be updated.
+	my $m1 = Test::MockModule->new('Module::Name', distinct => 1);
+	my $m2 = Test::MockModule->new('Module::Name', distinct => 1);
+	# $m1 and $m2 are independent. Tests that need this layering must
+	# opt in explicitly.
+
+Under C<distinct> mode the most recent C<mock>/C<redefine> call wins
+regardless of stack position; when a mock object is destroyed, the
+layer below it on the stack is reactivated; when all mock objects for
+a subroutine are destroyed, the original subroutine is restored.
 
 If there is no C<$VERSION> defined in C<$package>, the module will be
-automatically loaded. You can override this behaviour by setting the C<no_auto>
-option:
+automatically loaded. You can override this behaviour by setting the
+C<no_auto> option:
 
 	my $mock = Test::MockModule->new('Module::Name', no_auto => 1);
+
+B<GH #83 caveat for distinct mode>: a closure that captures C<$mock>
+(typically by calling C<< $mock->original(...) >> inside the mock body)
+prevents C<DESTROY> from firing when C<$mock> goes out of scope, so
+the mock leaks past its lexical scope. The default (singleton) mode
+makes this leak harmless by re-using the same object on subsequent
+C<new()> calls. Under C<< distinct => 1 >>, prefer the class-method
+form C<< Test::MockModule->original_for($pkg, $sub) >> from inside
+closures so they capture only strings, or capture
+C<< $mock->original(...) >> in a lexical B<before> calling C<mock()>.
 
 =item get_package()
 
@@ -947,6 +962,29 @@ one hardcoded argument pass to a function.
 			return $orig_get_path->($path, @_);
 		}
 	});
+
+
+=item original_for($package, $subroutine)
+
+Class-method counterpart to C<original()>. Returns the truly-original
+coderef for C<$package::$subroutine> from the per-package registry,
+or the live sub via the symbol table if not currently mocked. Returns
+C<undef> if no sub by that name exists. Croaks on invalid package or
+sub names.
+
+The motivating use case is letting closures reach the original sub
+without capturing C<$mock> -- the closure-capture pattern that drives
+the GH #83 leak under C<< distinct => 1 >> mode:
+
+	my $mock = Test::MockModule->new('MyModule', distinct => 1);
+	$mock->mock('greet', sub {
+		# Closure captures only strings -- $mock can be GC'd at scope end
+		return Test::MockModule
+			->original_for('MyModule', 'greet')->(@_) . '_suffix';
+	});
+
+For stacked mocks, returns the truly-original (pre-any-mock) coderef,
+not the layer below.
 
 
 =item unmock($subroutine [, ...])

--- a/lib/Test/MockModule.pm
+++ b/lib/Test/MockModule.pm
@@ -414,6 +414,32 @@ sub original {
 	return defined $self->{_orig}{$name} ? $self->{_orig}{$name} : $self->{_package}->super($name);
 }
 
+# Class-method counterpart to $mock->original(). Takes strings, returns
+# the truly-original coderef from the per-package registry (or the live
+# sub if not mocked). Lets user closures reach the original sub without
+# capturing $mock -- the closure-capture pattern that drives the GH #83
+# DESTROY-leak under `distinct => 1` mode.
+sub original_for {
+	my ($class, $package, $name) = @_;
+	croak "Invalid package name " . (defined $package ? $package : 'undef')
+		unless _valid_package($package);
+	croak 'Please provide a valid function name'
+		unless _valid_subname($name);
+
+	my $sub_name = "${package}::${name}";
+	my $stack = $mock_subs{$sub_name};
+	if ($stack && @$stack) {
+		# Bottom-of-stack orig is the truly-original. May be undef when
+		# the sub was created via define() -- that is expected. Falling
+		# through to \&$sub_name would hand back the active mock (an
+		# infinite-recursion footgun for closures wrapping their orig).
+		return $stack->[0]{orig};
+	}
+	no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
+	return \&$sub_name if defined &{$sub_name};
+	return;
+}
+
 sub unmock {
 	my ( $self, @names ) = @_;
 

--- a/t/author-perlcritic.t
+++ b/t/author-perlcritic.t
@@ -1,0 +1,14 @@
+#!perl
+use strict;
+use warnings;
+use Test::More;
+
+# Author/develop test: runs Perl::Critic against lib/ and t/ at the
+# project's --gentle severity. Skipped on machines without
+# Test::Perl::Critic so random CPAN testers do not fail because of an
+# author-only dep.
+eval { require Test::Perl::Critic };
+plan skip_all => 'Test::Perl::Critic not installed (author dep)' if $@;
+
+Test::Perl::Critic->import(-severity => 'gentle');
+all_critic_ok('lib', 't');

--- a/t/distinct_opt_in.t
+++ b/t/distinct_opt_in.t
@@ -1,0 +1,93 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::MockModule;
+use Scalar::Util qw(refaddr);
+
+package Tgt::DistinctOptIn; ## no critic (Modules::RequireFilenameMatchesPackage)
+our $VERSION = 1;
+sub greet { 'hello' }
+package main; ## no critic (Modules::RequireFilenameMatchesPackage)
+
+# 1. Default behavior: singleton-per-package (pre-v0.181, GH #83 fix)
+{
+    my $a = Test::MockModule->new('Tgt::DistinctOptIn');
+    my $b = Test::MockModule->new('Tgt::DistinctOptIn');
+    is(refaddr($a), refaddr($b),
+        'default new(): singleton-per-package (pre-v0.181 behavior)');
+}
+
+# 2. distinct => 1: fresh object per call (GH #48 opt-in)
+{
+    my $a = Test::MockModule->new('Tgt::DistinctOptIn', distinct => 1);
+    my $b = Test::MockModule->new('Tgt::DistinctOptIn', distinct => 1);
+    isnt(refaddr($a), refaddr($b),
+        'distinct => 1: fresh object per call (GH #48 opt-in)');
+}
+
+# 3. distinct => 1 enables independent multi-mock layering
+{
+    package Tgt::DistinctMulti; ## no critic (Modules::RequireFilenameMatchesPackage)
+    our $VERSION = 1;
+    sub foo { 'orig_foo' }
+    sub bar { 'orig_bar' }
+    package main; ## no critic (Modules::RequireFilenameMatchesPackage)
+
+    my $m1 = Test::MockModule->new('Tgt::DistinctMulti', distinct => 1);
+    $m1->mock('foo', sub { 'm1_foo' });
+    is(Tgt::DistinctMulti::foo(), 'm1_foo', 'm1 mocks foo');
+
+    {
+        my $m2 = Test::MockModule->new('Tgt::DistinctMulti', distinct => 1);
+        $m2->mock('bar', sub { 'm2_bar' });
+        is(Tgt::DistinctMulti::foo(), 'm1_foo', 'foo still mocked by m1');
+        is(Tgt::DistinctMulti::bar(), 'm2_bar', 'bar mocked by m2');
+    }
+
+    is(Tgt::DistinctMulti::bar(), 'orig_bar',
+        'bar restored after m2 destroyed');
+    $m1->unmock_all;
+    is(Tgt::DistinctMulti::foo(), 'orig_foo', 'foo restored after m1 unmock');
+}
+
+# 4. Singleton-default mode keeps the same object across run scopes,
+#    which is exactly what makes the documented `$mock->original` from-
+#    inside-closure pattern work without leaking.
+{
+    package Tgt::DistinctRun; ## no critic (Modules::RequireFilenameMatchesPackage)
+    our $VERSION = 1;
+    sub greet { 'run' }
+    package main; ## no critic (Modules::RequireFilenameMatchesPackage)
+
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt::DistinctRun', no_auto => 1);
+        $mock->mock('greet', sub {
+            return $mock->original('greet')->() . "_$label";
+        });
+        push @results, Tgt::DistinctRun::greet();
+    };
+    $run->('first');
+    $run->('second');
+    is_deeply \@results, ['run_first', 'run_second'],
+        'closure-captures-$mock pattern works under singleton default';
+
+    Test::MockModule->new('Tgt::DistinctRun', no_auto => 1)->unmock_all;
+}
+
+# 5. Mixing distinct and non-distinct: distinct always returns fresh,
+#    non-distinct returns the existing singleton if alive.
+{
+    my $s = Test::MockModule->new('Tgt::DistinctOptIn');
+    my $d = Test::MockModule->new('Tgt::DistinctOptIn', distinct => 1);
+    isnt(refaddr($s), refaddr($d),
+        'distinct => 1 returns a fresh object even when singleton exists');
+
+    my $s2 = Test::MockModule->new('Tgt::DistinctOptIn');
+    is(refaddr($s), refaddr($s2),
+        'subsequent default new() still returns the singleton');
+}
+
+done_testing;

--- a/t/distinct_opt_in.t
+++ b/t/distinct_opt_in.t
@@ -90,4 +90,31 @@ package main; ## no critic (Modules::RequireFilenameMatchesPackage)
         'subsequent default new() still returns the singleton');
 }
 
+# 6. Regression for Koan-Bot review on PR #85: a singleton seeded by an
+#    earlier `no_auto => 1` call must NOT deny later default-mode
+#    callers the module-load they expect. The autoload check runs
+#    before the singleton cache is consulted.
+{
+    # Use a fresh package name so no prior subtest seeded the singleton.
+    # The package has no $VERSION and no .pm on disk; a default new()
+    # call would normally die trying to require it. We seed a singleton
+    # with no_auto => 1, then verify the second default-mode call still
+    # tries to load the module.
+    my $pkg = 'Tgt::AutoloadAfterSingleton';
+    {
+        my $first = Test::MockModule->new($pkg, no_auto => 1);
+        ok($first, "no_auto seed: singleton created without loading $pkg");
+    }
+    # Second call WITHOUT no_auto should attempt the require and die
+    # because the package has no .pm. If the autoload-bypass bug is
+    # present, this would silently return the cached object instead.
+    my $err;
+    eval { Test::MockModule->new($pkg) };
+    $err = $@;
+    # require turns Pkg::Sub into Pkg/Sub.pm in its error message
+    (my $path = $pkg) =~ s{::}{/}g;
+    like($err, qr/Can't locate \Q$path\E\.pm/,
+        'default new() after no_auto-seed singleton still attempts autoload');
+}
+
 done_testing;

--- a/t/gh_83_no_leak.t
+++ b/t/gh_83_no_leak.t
@@ -1,0 +1,138 @@
+#!/usr/bin/env perl
+# GH #83 regression suite. Proves the bug pattern from the issue does
+# NOT leak under the default (singleton-per-package) mode, and that
+# original_for is the documented escape hatch under distinct => 1.
+use warnings;
+use strict;
+
+use Test::More;
+use Test::MockModule;
+use Scalar::Util qw(refaddr);
+
+sub make_pkg {
+    my ($pkg) = @_;
+    no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
+    *{"${pkg}::greet"} = sub { 'hello' };
+    *{"${pkg}::other"} = sub { 'other' };
+}
+
+sub installed_code {
+    my ($pkg, $name) = @_;
+    no strict 'refs'; ## no critic (TestingAndDebugging::ProhibitNoStrict)
+    return defined &{"${pkg}::${name}"} ? \&{"${pkg}::${name}"} : undef;
+}
+
+# 1. The literal reporter reproducer from GH #83. Used to fail in
+#    v0.181-0.184 where distinct-objects became the default; passes
+#    under singleton-default because the second new() returns the same
+#    $mock and the second mock() overwrites the leaked closure in the
+#    symbol table.
+subtest 'GH #83 reporter reproducer (default mode)' => sub {
+    package Tgt_Reporter; ## no critic (Modules::RequireFilenameMatchesPackage)
+    our $VERSION = 1;
+    sub greet { 'hello' }
+    package main; ## no critic (Modules::RequireFilenameMatchesPackage)
+
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_Reporter', no_auto => 1);
+        $mock->mock('greet', sub {
+            return $mock->original('greet')->() . "_$label";
+        });
+        push @results, Tgt_Reporter::greet();
+    };
+    $run->('first');
+    $run->('second');
+    is_deeply \@results, ['hello_first', 'hello_second'],
+        'reporter pattern: each iteration sees fresh mock';
+
+    Test::MockModule->new('Tgt_Reporter', no_auto => 1)->unmock_all;
+};
+
+# 2. redefine() variant of the reporter pattern, default mode.
+subtest 'redefine + $mock->original closure (default mode)' => sub {
+    make_pkg('Tgt_Redef');
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new('Tgt_Redef', no_auto => 1);
+        $mock->redefine('other', sub {
+            return $mock->original('other')->() . "_$label";
+        });
+        push @results, Tgt_Redef::other();
+    };
+    $run->('a');
+    $run->('b');
+    is_deeply \@results, ['other_a', 'other_b'], 'redefine path';
+
+    Test::MockModule->new('Tgt_Redef', no_auto => 1)->unmock_all;
+};
+
+# 3. Nested scope: under singleton default, the inner-scope mock is
+#    overwritten on the next mock() call rather than leaked.
+subtest 'nested scope (default mode)' => sub {
+    make_pkg('Tgt_Nested');
+    {
+        my $mock = Test::MockModule->new('Tgt_Nested', no_auto => 1);
+        $mock->mock('greet', sub { $mock->original('greet')->() . '_inner' });
+        is(Tgt_Nested::greet(), 'hello_inner', 'inside scope: mock active');
+    }
+    # Singleton mode: the leaked closure is still installed, but the
+    # singleton survived too. The next mock() call (or unmock_all) is
+    # what restores. Use unmock_all to restore for this regression test.
+    Test::MockModule->new('Tgt_Nested', no_auto => 1)->unmock_all;
+    is(Tgt_Nested::greet(), 'hello',
+        'after unmock_all: original restored');
+};
+
+# 4. Under `distinct => 1`, the closure-captures-$mock pattern WOULD
+#    leak. The recommended workaround is original_for. Verify it works.
+subtest 'original_for under distinct => 1 (no leak)' => sub {
+    make_pkg('Tgt_Distinct');
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new(
+            'Tgt_Distinct', no_auto => 1, distinct => 1
+        );
+        $mock->mock('greet', sub {
+            # No $mock capture -- only strings
+            return Test::MockModule
+                ->original_for('Tgt_Distinct', 'greet')->() . "_$label";
+        });
+        push @results, Tgt_Distinct::greet();
+    };
+    $run->('first');
+    $run->('second');
+    is_deeply \@results, ['hello_first', 'hello_second'],
+        'original_for pattern under distinct mode does not leak';
+};
+
+# 5. Symbol-table refaddr probe: proves the singleton-default mode
+#    actually sees the same closure replaced (not stacked) across
+#    iterations. Strongest direct evidence for the GH #83 fix.
+subtest 'symbol-table behavior under singleton default' => sub {
+    make_pkg('Tgt_SymProbe');
+    my $orig_addr = refaddr(installed_code('Tgt_SymProbe', 'greet'));
+    my @addrs_during;
+    {
+        my $mock = Test::MockModule->new('Tgt_SymProbe', no_auto => 1);
+        $mock->mock('greet', sub { $mock->original('greet')->() . '_x' });
+        push @addrs_during, refaddr(installed_code('Tgt_SymProbe', 'greet'));
+
+        # Re-mock: under singleton mode, the existing stack entry is
+        # updated; the symbol table holds the new closure.
+        $mock->mock('greet', sub { $mock->original('greet')->() . '_y' });
+        push @addrs_during, refaddr(installed_code('Tgt_SymProbe', 'greet'));
+    }
+    isnt($addrs_during[0], $orig_addr, 'first mock changes the symbol table');
+    isnt($addrs_during[0], $addrs_during[1],
+        're-mock installs a different closure');
+
+    Test::MockModule->new('Tgt_SymProbe', no_auto => 1)->unmock_all;
+    is(refaddr(installed_code('Tgt_SymProbe', 'greet')), $orig_addr,
+        'symbol table restored after unmock_all');
+};
+
+done_testing;

--- a/t/mockmodule.t
+++ b/t/mockmodule.t
@@ -37,8 +37,8 @@ like($@, qr/Invalid package name/, ' ... croaks if package is undefined');
 	ok($INC{'ExampleModule.pm'}, '... module loaded if !$VERSION');
 	ok($mcgi->isa('Test::MockModule'), '... returns a Test::MockModule object');
 	my $mcgi2 = Test::MockModule->new('ExampleModule');
-	isnt($mcgi, $mcgi2,
-		"... returns a new object even if one already exists for the package");
+	is($mcgi, $mcgi2,
+		"... returns the same singleton object on a subsequent call (default behavior)");
 
 	# get_package()
 	ok($mcgi->can('get_package'), 'get_package');

--- a/t/moose_multi.t
+++ b/t/moose_multi.t
@@ -22,11 +22,11 @@ use Test::MockModule;
 
 # LIFO unmock: top layer pops first, then bottom layer pops.
 {
-    my $m1 = Test::MockModule->new('MooseMulti::Local');
+    my $m1 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
     $m1->mock('greet', sub { 'A' });
     is(MooseMulti::Local->greet, 'A', 'LIFO: m1 mock active');
 
-    my $m2 = Test::MockModule->new('MooseMulti::Local');
+    my $m2 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
     $m2->mock('greet', sub { 'B' });
     is(MooseMulti::Local->greet, 'B', 'LIFO: m2 mock takes over');
 
@@ -44,10 +44,10 @@ use Test::MockModule;
 # pre-PR singleton implementation hid this case; the new design must keep
 # m2's mock active after m1 unmocks, and restore the original after both.
 {
-    my $m1 = Test::MockModule->new('MooseMulti::Local');
+    my $m1 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
     $m1->mock('greet', sub { 'A' });
 
-    my $m2 = Test::MockModule->new('MooseMulti::Local');
+    my $m2 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
     $m2->mock('greet', sub { 'B' });
     is(MooseMulti::Local->greet, 'B', 'non-LIFO: m2 active');
 
@@ -65,10 +65,10 @@ use Test::MockModule;
 # subsequent mid-stack unmock must hand control back to the still-living
 # top layer rather than leaving the stale install in the meta.
 {
-    my $m1 = Test::MockModule->new('MooseMulti::Local');
+    my $m1 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
     $m1->mock('greet', sub { 'A' });
 
-    my $m2 = Test::MockModule->new('MooseMulti::Local');
+    my $m2 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
     $m2->mock('greet', sub { 'B' });
 
     $m1->mock('greet', sub { 'C' });
@@ -89,10 +89,10 @@ use Test::MockModule;
 {
     my $m2;
     {
-        my $m1 = Test::MockModule->new('MooseMulti::Local');
+        my $m1 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
         $m1->mock('greet', sub { 'A' });
 
-        $m2 = Test::MockModule->new('MooseMulti::Local');
+        $m2 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
         $m2->mock('greet', sub { 'B' });
         # m1 destructed here.
     }
@@ -106,10 +106,10 @@ use Test::MockModule;
 # Independent mocks on different methods: m1 mocks one method, m2 mocks a
 # different method. Each unmock must only affect its own method.
 {
-    my $m1 = Test::MockModule->new('MooseMulti::Local');
+    my $m1 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
     $m1->mock('greet', sub { 'AA' });
 
-    my $m2 = Test::MockModule->new('MooseMulti::Local');
+    my $m2 = Test::MockModule->new('MooseMulti::Local', distinct => 1);
     $m2->mock('other', sub { 'BB' });
 
     is(MooseMulti::Local->greet, 'AA', 'independent: greet from m1');
@@ -141,10 +141,10 @@ use Test::MockModule;
 }
 
 {
-    my $m1 = Test::MockModule->new('MooseMulti::Child');
+    my $m1 = Test::MockModule->new('MooseMulti::Child', distinct => 1);
     $m1->mock('bar', sub { 'child_A' });
 
-    my $m2 = Test::MockModule->new('MooseMulti::Child');
+    my $m2 = Test::MockModule->new('MooseMulti::Child', distinct => 1);
     $m2->mock('bar', sub { 'child_B' });
     is(MooseMulti::Child->bar, 'child_B', 'inherited: m2 mock visible');
 
@@ -174,7 +174,7 @@ use Test::MockModule;
 }
 
 {
-    my $m1 = Test::MockModule->new('MooseMulti::Toggle');
+    my $m1 = Test::MockModule->new('MooseMulti::Toggle', distinct => 1);
     {
         local $SIG{__WARN__} = sub {};   # swallow the immutable carp
         $m1->mock('greet', sub { 'A' });
@@ -183,7 +183,7 @@ use Test::MockModule;
 
     MooseMulti::Toggle->meta->make_mutable;
 
-    my $m2 = Test::MockModule->new('MooseMulti::Toggle');
+    my $m2 = Test::MockModule->new('MooseMulti::Toggle', distinct => 1);
     $m2->mock('greet', sub { 'B' });
     is(MooseMulti::Toggle->greet, 'B', 'toggle: m2 mock active (meta path)');
 

--- a/t/mouse_multi.t
+++ b/t/mouse_multi.t
@@ -21,11 +21,11 @@ use Test::MockModule;
 
 # LIFO unmock
 {
-    my $m1 = Test::MockModule->new('MouseMulti::Local');
+    my $m1 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
     $m1->mock('greet', sub { 'A' });
     is(MouseMulti::Local->greet, 'A', 'LIFO: m1 mock active');
 
-    my $m2 = Test::MockModule->new('MouseMulti::Local');
+    my $m2 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
     $m2->mock('greet', sub { 'B' });
     is(MouseMulti::Local->greet, 'B', 'LIFO: m2 mock takes over');
 
@@ -41,10 +41,10 @@ use Test::MockModule;
 
 # Non-LIFO unmock (the case the singleton previously hid)
 {
-    my $m1 = Test::MockModule->new('MouseMulti::Local');
+    my $m1 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
     $m1->mock('greet', sub { 'A' });
 
-    my $m2 = Test::MockModule->new('MouseMulti::Local');
+    my $m2 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
     $m2->mock('greet', sub { 'B' });
     is(MouseMulti::Local->greet, 'B', 'non-LIFO: m2 active');
 
@@ -59,10 +59,10 @@ use Test::MockModule;
 
 # Non-top re-mock + mid-stack unmock
 {
-    my $m1 = Test::MockModule->new('MouseMulti::Local');
+    my $m1 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
     $m1->mock('greet', sub { 'A' });
 
-    my $m2 = Test::MockModule->new('MouseMulti::Local');
+    my $m2 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
     $m2->mock('greet', sub { 'B' });
 
     $m1->mock('greet', sub { 'C' });
@@ -82,10 +82,10 @@ use Test::MockModule;
 {
     my $m2;
     {
-        my $m1 = Test::MockModule->new('MouseMulti::Local');
+        my $m1 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
         $m1->mock('greet', sub { 'A' });
 
-        $m2 = Test::MockModule->new('MouseMulti::Local');
+        $m2 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
         $m2->mock('greet', sub { 'B' });
         # m1 destructed here.
     }
@@ -98,10 +98,10 @@ use Test::MockModule;
 
 # Independent methods
 {
-    my $m1 = Test::MockModule->new('MouseMulti::Local');
+    my $m1 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
     $m1->mock('greet', sub { 'AA' });
 
-    my $m2 = Test::MockModule->new('MouseMulti::Local');
+    my $m2 = Test::MockModule->new('MouseMulti::Local', distinct => 1);
     $m2->mock('other', sub { 'BB' });
 
     is(MouseMulti::Local->greet, 'AA', 'independent: greet from m1');
@@ -131,10 +131,10 @@ use Test::MockModule;
 }
 
 {
-    my $m1 = Test::MockModule->new('MouseMulti::Child');
+    my $m1 = Test::MockModule->new('MouseMulti::Child', distinct => 1);
     $m1->mock('bar', sub { 'child_A' });
 
-    my $m2 = Test::MockModule->new('MouseMulti::Child');
+    my $m2 = Test::MockModule->new('MouseMulti::Child', distinct => 1);
     $m2->mock('bar', sub { 'child_B' });
     is(MouseMulti::Child->bar, 'child_B', 'inherited: m2 mock visible');
 
@@ -159,7 +159,7 @@ use Test::MockModule;
 }
 
 {
-    my $m1 = Test::MockModule->new('MouseMulti::Toggle');
+    my $m1 = Test::MockModule->new('MouseMulti::Toggle', distinct => 1);
     {
         local $SIG{__WARN__} = sub {};   # swallow the immutable carp
         $m1->mock('greet', sub { 'A' });
@@ -168,7 +168,7 @@ use Test::MockModule;
 
     MouseMulti::Toggle->meta->make_mutable;
 
-    my $m2 = Test::MockModule->new('MouseMulti::Toggle');
+    my $m2 = Test::MockModule->new('MouseMulti::Toggle', distinct => 1);
     $m2->mock('greet', sub { 'B' });
     is(MouseMulti::Toggle->greet, 'B', 'toggle: m2 mock active (meta path)');
 

--- a/t/multiple_objects.t
+++ b/t/multiple_objects.t
@@ -16,8 +16,8 @@ package main; ## no critic (Modules::RequireFilenameMatchesPackage)
 
 # Basic: new() returns distinct objects
 {
-    my $m1 = Test::MockModule->new('Stacked');
-    my $m2 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
+    my $m2 = Test::MockModule->new('Stacked', distinct => 1);
     isnt($m1, $m2, 'new() returns distinct objects for same package');
     is($m1->get_package, 'Stacked', '... both target the same package');
     is($m2->get_package, 'Stacked', '... both target the same package');
@@ -25,13 +25,13 @@ package main; ## no critic (Modules::RequireFilenameMatchesPackage)
 
 # Independent mocking: different subs on different objects
 {
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'mock1_foo' });
     is(Stacked::foo(), 'mock1_foo', 'first object mocks foo');
     is(Stacked::bar(), 'original_bar', 'bar is untouched');
 
     {
-        my $m2 = Test::MockModule->new('Stacked');
+        my $m2 = Test::MockModule->new('Stacked', distinct => 1);
         $m2->mock('bar', sub { 'mock2_bar' });
         is(Stacked::foo(), 'mock1_foo', 'foo still mocked by first object');
         is(Stacked::bar(), 'mock2_bar', 'bar mocked by second object');
@@ -45,12 +45,12 @@ is(Stacked::foo(), 'original_foo', 'foo restored after first object destroyed');
 
 # Stacked mocking: same sub, LIFO destruction order
 {
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'layer1' });
     is(Stacked::foo(), 'layer1', 'first layer');
 
     {
-        my $m2 = Test::MockModule->new('Stacked');
+        my $m2 = Test::MockModule->new('Stacked', distinct => 1);
         $m2->mock('foo', sub { 'layer2' });
         is(Stacked::foo(), 'layer2', 'second layer overrides first');
     }
@@ -64,10 +64,10 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 {
     my $m2;
     {
-        my $m1 = Test::MockModule->new('Stacked');
+        my $m1 = Test::MockModule->new('Stacked', distinct => 1);
         $m1->mock('foo', sub { 'layer1' });
 
-        $m2 = Test::MockModule->new('Stacked');
+        $m2 = Test::MockModule->new('Stacked', distinct => 1);
         $m2->mock('foo', sub { 'layer2' });
         is(Stacked::foo(), 'layer2', 'layer2 active');
     }
@@ -81,13 +81,13 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 
 # Three layers
 {
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'L1' });
 
-    my $m2 = Test::MockModule->new('Stacked');
+    my $m2 = Test::MockModule->new('Stacked', distinct => 1);
     $m2->mock('foo', sub { 'L2' });
 
-    my $m3 = Test::MockModule->new('Stacked');
+    my $m3 = Test::MockModule->new('Stacked', distinct => 1);
     $m3->mock('foo', sub { 'L3' });
 
     is(Stacked::foo(), 'L3', 'three layers: top wins');
@@ -107,10 +107,10 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 
 # Explicit unmock interacts correctly with stack
 {
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'A' });
 
-    my $m2 = Test::MockModule->new('Stacked');
+    my $m2 = Test::MockModule->new('Stacked', distinct => 1);
     $m2->mock('foo', sub { 'B' });
 
     is(Stacked::foo(), 'B', 'B is active');
@@ -124,10 +124,10 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 
 # is_mocked is per-object
 {
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'x' });
 
-    my $m2 = Test::MockModule->new('Stacked');
+    my $m2 = Test::MockModule->new('Stacked', distinct => 1);
 
     ok($m1->is_mocked('foo'), 'm1 reports foo as mocked');
     ok(!$m2->is_mocked('foo'), 'm2 does not report foo as mocked');
@@ -140,10 +140,10 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 # original() returns the correct original per object
 {
     my $orig_foo = \&Stacked::foo;
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'first' });
 
-    my $m2 = Test::MockModule->new('Stacked');
+    my $m2 = Test::MockModule->new('Stacked', distinct => 1);
     $m2->mock('foo', sub { 'second' });
 
     is($m1->original('foo'), $orig_foo, 'm1 original is the true original');
@@ -154,10 +154,10 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 # Re-mock by a non-top object: when the top unmocks, the non-top object's
 # most recent install should be active, not its initial install.
 {
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'm1_v1' });
 
-    my $m2 = Test::MockModule->new('Stacked');
+    my $m2 = Test::MockModule->new('Stacked', distinct => 1);
     $m2->mock('foo', sub { 'm2' });
     is(Stacked::foo(), 'm2', 're-mock setup: m2 active');
 
@@ -176,10 +176,10 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 
 # Re-mock by top object also stays consistent
 {
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'a' });
 
-    my $m2 = Test::MockModule->new('Stacked');
+    my $m2 = Test::MockModule->new('Stacked', distinct => 1);
     $m2->mock('foo', sub { 'b1' });
     $m2->mock('foo', sub { 'b2' });
     is(Stacked::foo(), 'b2', 'top re-mock active');
@@ -194,10 +194,10 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 # "most recent mock wins" contract), so when that layer is removed the
 # symbol must be restored to the layer that's still on top.
 {
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'A' });
 
-    my $m2 = Test::MockModule->new('Stacked');
+    my $m2 = Test::MockModule->new('Stacked', distinct => 1);
     $m2->mock('foo', sub { 'B' });
 
     # Non-top re-mock by m1 clobbers the symbol to C.
@@ -218,10 +218,10 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 {
     my $m2;
     {
-        my $m1 = Test::MockModule->new('Stacked');
+        my $m1 = Test::MockModule->new('Stacked', distinct => 1);
         $m1->mock('foo', sub { 'A' });
 
-        $m2 = Test::MockModule->new('Stacked');
+        $m2 = Test::MockModule->new('Stacked', distinct => 1);
         $m2->mock('foo', sub { 'B' });
 
         $m1->mock('foo', sub { 'C' });          # non-top re-mock
@@ -240,13 +240,13 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
 # must be re-installed; the bottom layer remains untouched and is restored
 # correctly when the top eventually unmocks.
 {
-    my $m1 = Test::MockModule->new('Stacked');
+    my $m1 = Test::MockModule->new('Stacked', distinct => 1);
     $m1->mock('foo', sub { 'L1' });
 
-    my $m2 = Test::MockModule->new('Stacked');
+    my $m2 = Test::MockModule->new('Stacked', distinct => 1);
     $m2->mock('foo', sub { 'L2' });
 
-    my $m3 = Test::MockModule->new('Stacked');
+    my $m3 = Test::MockModule->new('Stacked', distinct => 1);
     $m3->mock('foo', sub { 'L3' });
 
     $m2->mock('foo', sub { 'L2_new' });        # middle re-mock; clobbers symbol
@@ -275,10 +275,10 @@ is(Stacked::foo(), 'original_foo', 'original restored after all objects destroye
     package main;
     ok(!defined &Stacked64::wrapper, 'Stacked64::wrapper does not exist initially');
 
-    my $m1 = Test::MockModule->new('Stacked64', no_auto => 1);
+    my $m1 = Test::MockModule->new('Stacked64', no_auto => 1, distinct => 1);
     $m1->define('wrapper', sub { 'defined_value' });
 
-    my $m2 = Test::MockModule->new('Stacked64', no_auto => 1);
+    my $m2 = Test::MockModule->new('Stacked64', no_auto => 1, distinct => 1);
     $m2->mock('wrapper', sub { 'sibling_value' });
 
     # m1 (non-top) redefines its own defined sub. Per the documented

--- a/t/original_for.t
+++ b/t/original_for.t
@@ -1,0 +1,85 @@
+use warnings;
+use strict;
+
+use Test::More;
+use Test::MockModule;
+
+package Tgt::OriginalFor; ## no critic (Modules::RequireFilenameMatchesPackage)
+our $VERSION = 1;
+sub greet { 'hello' }
+sub other { 'other' }
+package main; ## no critic (Modules::RequireFilenameMatchesPackage)
+
+# 1. Returns the actual sub when not mocked
+{
+    my $code = Test::MockModule->original_for('Tgt::OriginalFor', 'greet');
+    is(ref($code), 'CODE', 'returns a coderef when sub is not mocked');
+    is($code->(), 'hello', '... that calls the real implementation');
+}
+
+# 2. Returns the truly-original (not the active mock) when mocked
+{
+    my $mock = Test::MockModule->new('Tgt::OriginalFor');
+    $mock->mock('greet', sub { 'mocked' });
+
+    is(Tgt::OriginalFor::greet(), 'mocked', 'symbol table now holds the mock');
+
+    my $orig = Test::MockModule->original_for('Tgt::OriginalFor', 'greet');
+    is($orig->(), 'hello',
+        'original_for returns the pre-mock implementation, not the mock');
+
+    $mock->unmock_all;
+}
+
+# 3. Recommended GH #83-safe pattern: closure captures strings, not $mock.
+#    Works under distinct => 1 mode because there is no $mock capture.
+{
+    my @results;
+    my $run = sub {
+        my ($label) = @_;
+        my $mock = Test::MockModule->new(
+            'Tgt::OriginalFor', no_auto => 1, distinct => 1
+        );
+        $mock->mock('greet', sub {
+            return Test::MockModule
+                ->original_for('Tgt::OriginalFor', 'greet')->() . "_$label";
+        });
+        push @results, Tgt::OriginalFor::greet();
+    };
+    $run->('first');
+    $run->('second');
+    is_deeply \@results, ['hello_first', 'hello_second'],
+        'original_for pattern works under distinct => 1 (no leak)';
+}
+
+# 4. Stacked mocks: original_for still returns the truly-original
+{
+    my $m1 = Test::MockModule->new('Tgt::OriginalFor', distinct => 1);
+    $m1->mock('other', sub { 'L1' });
+    {
+        my $m2 = Test::MockModule->new('Tgt::OriginalFor', distinct => 1);
+        $m2->mock('other', sub { 'L2' });
+        is(Tgt::OriginalFor::other(), 'L2', 'top mock wins');
+        my $orig = Test::MockModule->original_for('Tgt::OriginalFor', 'other');
+        is($orig->(), 'other',
+            'original_for returns pre-any-mock impl, not the layer below');
+    }
+    $m1->unmock_all;
+}
+
+# 5. Invalid args croak
+{
+    eval { Test::MockModule->original_for('', 'foo') };
+    like($@, qr/Invalid package name/, 'empty package croaks');
+
+    eval { Test::MockModule->original_for('Tgt::OriginalFor', '') };
+    like($@, qr/valid function name/i, 'empty sub name croaks');
+}
+
+# 6. Looking up a sub that doesn't exist returns undef without crashing
+{
+    my $code = Test::MockModule->original_for('Tgt::OriginalFor', 'nonexistent');
+    is($code, undef, 'returns undef for nonexistent sub');
+}
+
+done_testing;


### PR DESCRIPTION
Closes #83. Replaces #84.

## What changed vs #84

Pivoted to the simpler architectural fix per @rku's analysis on the issue: instead of adding four escape paths (PadWalker warning, opt-in singleton, `reset_for`, `original_for`) on top of the v0.181 default, just revert the default. GH #48 changed long-standing behavior 6 days ago and broke a documented decade-old pattern; making the new behavior opt-in is the more conservative path.

## Changes

- **`new()` default flipped back to singleton-per-package** (pre-v0.181 contract). Two `Test::MockModule->new('Foo')` calls return the same object as long as one is alive.
- **`distinct => 1` opt-in flag** for the v0.181 GH #48 stacking semantics. Tests that need multiple coexisting mock objects on the same package pass `distinct => 1`; the per-sub stack architecture is unchanged.
- **`Test::MockModule->original_for($pkg, $sub)`** — class-method counterpart to `$mock->original`. Pure addition; lets closures call into the original sub without capturing `$mock`. Recommended pattern under `distinct => 1` to avoid the leak.
- **`t/multiple_objects.t`, `t/moose_multi.t`, `t/mouse_multi.t`** updated to pass `distinct => 1` — they cover the GH #48 stacking semantics, which is now opt-in.
- **`t/mockmodule.t`** assertion flipped: default behavior is singleton again.

## Dropped from #84

No PadWalker dep. No perl floor bump. No `_detect_self_capture` warning. No `singleton => 1` flag (it's the default). No `reset_for` (not needed when default doesn't leak).

## Bundled improvements (also in #84)

- `t/author-perlcritic.t` integrates perlcritic into `prove -l t/` under `AUTHOR_TESTING=1` so lint regressions surface before push, not in CI. `./Build critic` is the standalone invocation.
- `.github/workflows/testsuite.yml` switched to `cpanm --installdeps --notest .` — Build.PL is now the single source of truth for deps, and the matrix-job sudo-in-container failure mode is gone.

## Test plan

- [x] `prove -l t/` — 355/355
- [x] `AUTHOR_TESTING=1 prove -l t/` — 393/393 (adds 38 perlcritic file-checks)
- [x] `perlcritic --gentle lib/ t/` — clean
- [x] Reporter's literal reproducer from #83 passes under default mode (`t/gh_83_no_leak.t` subtest 1)
- [x] `original_for` pattern under `distinct => 1` does NOT leak (subtest 4)
- [x] `t/multiple_objects.t`, `t/moose_multi.t`, `t/mouse_multi.t` — full GH #48 coverage preserved as opt-in
