### PR TITLE
fix(GH #87): gate author-perlcritic.t behind AUTHOR_TESTING

### DIFF
--- a/t/author-perlcritic.t
+++ b/t/author-perlcritic.t
@@ -4,9 +4,13 @@ use warnings;
 use Test::More;
 
 # Author/develop test: runs Perl::Critic against lib/ and t/ at the
-# project's --gentle severity. Skipped on machines without
-# Test::Perl::Critic so random CPAN testers do not fail because of an
-# author-only dep.
+# project's --gentle severity. Gated behind AUTHOR_TESTING so installers
+# and CPAN testers (who may carry their own perlcritic policies) never
+# run it -- only the author and CI (AUTHOR_TESTING=1) do. The install
+# guard below is a second layer for the author-only dep.
+plan skip_all => 'Author test; set AUTHOR_TESTING=1 to run'
+    unless $ENV{AUTHOR_TESTING};
+
 eval { require Test::Perl::Critic };
 plan skip_all => 'Test::Perl::Critic not installed (author dep)' if $@;
 


### PR DESCRIPTION
t/author-perlcritic.t previously ran whenever Test::Perl::Critic was installed, with no author-test guard. On a system where an installer or CPAN tester carries their own perlcritic policies, the test fired against those policies and failed (reported in GH #87 against the 0.185.0 release). The -severity argument does not prevent extra policies a user has configured from running.

Gate the test behind $ENV{AUTHOR_TESTING} so it only runs for the author and in CI, which already sets AUTHOR_TESTING=1. This completes the intent already documented in the testsuite workflow comment ("so the lint test runs in CI under AUTHOR_TESTING=1") that was never wired into the test. The existing module-install check is kept as a second guard.

No change in CI coverage; arbitrary user systems now skip the test instead of failing on local perlcritic configuration.

Closes #87